### PR TITLE
Rename the track repository

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "vbnet",
   "language": "VB.NET",
-  "repository": "https://github.com/exercism/xvbnet",
+  "repository": "https://github.com/exercism/vbnet",
   "checklist_issue": 3,
   "active": false,
   "deprecated": [


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

See https://github.com/exercism/meta/issues/1