### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,10 +4,11 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+### Submitting Exercises
+
+Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/vbnet/<exerciseName>` directory.
+
+For example, if you're submitting `bob.vb` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/vbnet/bob/bob.vb`.{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -1,5 +1,0 @@
-### Submitting Exercises
-
-Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/vbnet/<exerciseName>` directory.
-
-For example, if you're submitting `bob.vb` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/vbnet/bob/bob.vb`.

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -25,9 +25,6 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
-Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
-as this is idiomatic Lisp, not a library function.
-
 ### Submitting Exercises
 
 Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/vbnet/<exerciseName>` directory.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -29,7 +29,6 @@ allergens that score 256, 512, 1024, etc.).  Your program should
 ignore those components of the score.  For example, if the allergy
 score is 257, your program should only report the eggs (1) allergy.
 
-
 ### Submitting Exercises
 
 Note that, when trying to submit an exercise, make sure you're exercise file you're submitting is in the `exercism/vbnet/<exerciseName>` directory.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -9,7 +9,7 @@ letter, the second with the second-last, and so on.
 
 An Atbash cipher for the Latin alphabet would be as follows:
 
-```plain
+```text
 Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
@@ -23,6 +23,7 @@ being 5 letters, and punctuation is excluded. This is to make it harder to guess
 things based on word boundaries.
 
 ## Examples
+
 - Encoding `test` gives `gvhg`
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -7,10 +7,12 @@ string, your program should produce a decimal output. The
 program should handle invalid inputs.
 
 ## Note
+
 - Implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 
 ## About Binary (Base-2)
+
 Decimal is a base-10 system.
 
 A number 23 in base 10 notation can be understood

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -26,7 +26,7 @@ and `r` is the number of rows.
 Our normalized text is 54 characters long, dictating a rectangle with
 `c = 8` and `r = 7`:
 
-```plain
+```text
 ifmanwas
 meanttos
 tayonthe
@@ -41,22 +41,24 @@ right.
 
 The message above is coded as:
 
-```plain
+```text
 imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect squares
-`(r X r)` should be output in `r`-length chunks separated by spaces.
-Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+Output the encoded text in chunks.  Phrases that fill perfect rectangles
+`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
+Phrases that do not fill perfect rectangles will have `n` empty spaces.
+Those spaces should be distributed evenly, added to the end of the last
+`n` chunks.
 
-```plain
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+```text
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
 ```
 
 Notice that were we to stack these, we could visually decode the
 cyphertext back in to the original message:
 
-```plain
+```text
 imtgdvs
 fearwer
 mayoogo


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94