### PR TITLE
crypto-square: update to latest canonical data

### DIFF
--- a/exercises/practice/crypto-square/.meta/Example.vb
+++ b/exercises/practice/crypto-square/.meta/Example.vb
@@ -1,54 +1,41 @@
-Imports System.Text
+Imports System.Runtime.CompilerServices
 
-Public Class Crypto
-    Property NormalizePlaintext As String
-    Property Size As Integer
-
-	Public Sub New(value As String)
-        NormalizePlaintext = NormalizeText(value)
-		Size = GetSquareSize(NormalizePlaintext)
-	End Sub
-
-	Private Shared Function NormalizeText(text As String) As String
-		Return String.Concat(text.ToLower().Where(AddressOf Char.IsLetterOrDigit))
+Module Crypto
+	Public Function Ciphertext(plaintext As String) As String
+		If plaintext.Length = 0
+			Return ""
+		Else
+			Return String.Join(" ", plaintext.Normalized().Rows().Columns())
+		End If
+	End Function
+	
+	<Extension>
+	Private Function Normalized(str As String) As String
+		Return New String(str.Where(AddressOf Char.IsLetterOrDigit).Select(AddressOf Char.ToLower).ToArray())
+	End Function
+	
+	<Extension>
+	Private Function Size(str As String) As Integer
+		Return Math.Ceiling(Math.Sqrt(str.length))
+	End Function
+	
+	<Extension>
+	Private Function Rows(str As String) As List(Of String)
+		Dim size = str.Size()
+		Return str.Chunks(size).Select(Function(row) row.PadRight(size)).ToList()
 	End Function
 
-	Private Shared Function GetSquareSize(text As String) As Integer
-		Return CInt(Math.Truncate(Math.Ceiling(Math.Sqrt(text.Length))))
+	<Extension>
+	Private Function Columns(rows As List(Of String)) As List(Of String)
+		Return Enumerable.Range(0, rows(0).Length).
+			Select(Function(i) String.Concat(rows.Select(Function(row) row(i)))).
+			ToList()
 	End Function
 
-	Public Function PlaintextSegments() As String()
-		Return SegmentText(NormalizePlaintext, Size)
-	End Function
-
-	Private Shared Function SegmentText(text As String, size As Integer) As String()
-		Dim segments = New List(Of String)()
-		Dim idx = 0
-		While idx < text.Length
-			If idx + size < text.Length Then
-				segments.Add(text.Substring(idx, size))
-			Else
-				segments.Add(text.Substring(idx))
-			End If
-			idx += size
-		End While
-		Return segments.ToArray()
-	End Function
-
-	Public Function Ciphertext() As String
-		Dim ciphertext__1 = New StringBuilder(NormalizePlaintext.Length)
-
-		For i As Integer = 0 To Size - 1
-            For Each segment In PlaintextSegments()
-                If i < segment.Length Then
-                    ciphertext__1.Append(segment(i))
-                End If
-            Next
+	<Extension>
+	Private Iterator Function Chunks(str As String, size As Integer) As IEnumerable(Of String)
+		For i = 0 To str.Length - 1 Step size
+			Yield str.Substring(i, Math.Min(str.Length - i, size))
 		Next
-		Return ciphertext__1.ToString()
 	End Function
-
-	Public Function NormalizeCiphertext() As String
-		Return String.Join(" ", SegmentText(Ciphertext(), 5))
-	End Function
-End Class
+End Module

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": ["brent113"],
-  "contributors": ["axtens"],
+  "contributors": ["axtens", "erikschierboom"],
   "files": {
     "solution": ["CryptoSquare.vb"],
     "test": ["CryptoSquareTests.vb"],

--- a/exercises/practice/crypto-square/CryptoSquare.vb
+++ b/exercises/practice/crypto-square/CryptoSquare.vb
@@ -1,3 +1,5 @@
-Public Class Crypto
-
-End Class
+Module Crypto
+	Public Function Ciphertext(ByVal plaintext As String) As String
+		Throw New NotImplementedException("You need to implement this function")
+	End Function
+End Module

--- a/exercises/practice/crypto-square/CryptoSquareTests.vb
+++ b/exercises/practice/crypto-square/CryptoSquareTests.vb
@@ -2,80 +2,44 @@ Imports XUnit
 
 Public Class CryptoSquareTest
     <Fact>
-    Public Sub StrangeCharactersAreStrippedDuringNormalization()
-        Dim crypto = New Crypto("s#$%^&plunk")
-        Assert.Equal(crypto.NormalizePlaintext, "splunk")
+    Public Sub EmptyPlaintextResultsInAnEmptyplaintext()
+        Dim plaintext = ""
+        Assert.Equal("", Ciphertext(plaintext))
+    End Sub
+    
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Lowercase()
+        Dim plaintext = "A"
+        Assert.Equal("a", Ciphertext(plaintext))
+    End Sub
+    
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub RemoveSpaces()
+        Dim plaintext = "  b "
+        Assert.Equal("b", Ciphertext(plaintext))
+    End Sub
+    
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub RemovePunctuation()
+        Dim plaintext = "@1,%!"
+        Assert.Equal("1", Ciphertext(plaintext))
+    End Sub
+    
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub NineCharacterPlaintextResultsInThreeChunksOfThreeCharacters()
+        Dim plaintext = "This is fun!"
+        Assert.Equal("tsf hiu isn", Ciphertext(plaintext))
     End Sub
 
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub LettersAreLowercasedDuringNormalization()
-        Dim crypto = New Crypto("WHOA HEY!")
-        Assert.Equal(crypto.NormalizePlaintext, "whoahey")
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub EightCharacterPlaintextResultsInThreeChunksTheLastOneWithATrailingSpace()
+        Dim plaintext = "Chill out."
+        Assert.Equal("clu hlt io ", Ciphertext(plaintext))
     End Sub
 
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub NumbersAreKeptDuringNormalization()
-        Dim crypto = New Crypto("1, 2, 3, GO!")
-        Assert.Equal(crypto.NormalizePlaintext, "123go")
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SmallestSquareSizeIs2()
-        Dim crypto = New Crypto("1234")
-        Assert.Equal(crypto.Size, 2)
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SizeOfTextWhoseLengthIsAPerfectSquareIsItsSquareRoot()
-        Dim crypto = New Crypto("123456789")
-        Assert.Equal(crypto.Size, 3)
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SizeOfTextWhoseLengthIsNotAPerfectSquareIsNextBiggestSquareRoot()
-        Dim crypto = New Crypto("123456789abc")
-        Assert.Equal(crypto.Size, 4)
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SizeIsDeterminedByNormalizedText()
-        Dim crypto = New Crypto("Oh hey, this is nuts!")
-        Assert.Equal(crypto.Size, 4)
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SegmentsAreSplitBySquareSize()
-        Dim crypto = New Crypto("Never vex thine heart with idle woes")
-        Assert.Equal(crypto.PlaintextSegments(), New String() {"neverv", "exthin", "eheart", "withid", "lewoes"})
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub SegmentsAreSplitBySquareSizeUntilTextRunsOut()
-        Dim crypto = New Crypto("ZOMG! ZOMBIES!!!")
-        Assert.Equal(crypto.PlaintextSegments(), New String() {"zomg", "zomb", "ies"})
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub CiphertextCombinesTextByColumn()
-        Dim crypto = New Crypto("First, solve the problem. Then, write the code.")
-        Assert.Equal(crypto.Ciphertext(), "foeewhilpmrervrticseohtottbeedshlnte")
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub CiphertextSkipsCellsWithNoText()
-        Dim crypto = New Crypto("Time is an illusion. Lunchtime doubly so.")
-        Assert.Equal(crypto.Ciphertext(), "tasneyinicdsmiohooelntuillibsuuml")
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub NormalizedCiphertextIsSplitBy5()
-        Dim crypto = New Crypto("Vampires are people too!")
-        Assert.Equal(crypto.NormalizeCiphertext(), "vrela epems etpao oirpo")
-    End Sub
-
-	<Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub NormalizedCiphertextNotExactlyDivisibleBy5SpillsIntoASmallerSegment()
-        Dim crypto = New Crypto("Madness, and then illumination.")
-        Assert.Equal(crypto.NormalizeCiphertext(), "msemo aanin dninn dlaet ltshu i")
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub FiftyFourCharacterPlaintextResultsInSevenChunksTheTwoWithTrailingSpaces()
+        Dim plaintext = "If man was meant to stay on the ground, god would have given us roots."
+        Assert.Equal("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", Ciphertext(plaintext))
     End Sub
 End Class


### PR DESCRIPTION
This PR updates the exercise to the latest canonical data. This resulted in several changes:

1. The class-based approach was replaced with a module-based approach
2. The expected/actual values in the Assert.Equals are now in the correct order
3. The implementation is a little bit simpler﻿, as the individual methods didn't really build upon each other that well in the current implementation