### PR TITLE
Upgrade to .NET 9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab
         with:
-          dotnet-version: "7.0.100"
+          dotnet-version: "9.0.200"
       - run: ./test.ps1
         shell: pwsh

--- a/exercises/practice/accumulate/Accumulate.vbproj
+++ b/exercises/practice/accumulate/Accumulate.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/accumulate/Accumulate.vbproj
+++ b/exercises/practice/accumulate/Accumulate.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/acronym/Acronym.vbproj
+++ b/exercises/practice/acronym/Acronym.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/acronym/Acronym.vbproj
+++ b/exercises/practice/acronym/Acronym.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/affine-cipher/AffineCipher.vbproj
+++ b/exercises/practice/affine-cipher/AffineCipher.vbproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/affine-cipher/AffineCipher.vbproj
+++ b/exercises/practice/affine-cipher/AffineCipher.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/all-your-base/AllYourBase.vbproj
+++ b/exercises/practice/all-your-base/AllYourBase.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/all-your-base/AllYourBase.vbproj
+++ b/exercises/practice/all-your-base/AllYourBase.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/all-your-base/AllYourBaseTests.vb
+++ b/exercises/practice/all-your-base/AllYourBaseTests.vb
@@ -7,7 +7,8 @@ Public Class AllYourBaseTests
         Dim digits = {1}
         Dim outputBase = 10
         Dim expected = {1}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -16,7 +17,8 @@ Public Class AllYourBaseTests
         Dim digits = {1, 0, 1}
         Dim outputBase = 10
         Dim expected = {5}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -25,7 +27,8 @@ Public Class AllYourBaseTests
         Dim digits = {5}
         Dim outputBase = 2
         Dim expected = {1, 0, 1}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -34,7 +37,8 @@ Public Class AllYourBaseTests
         Dim digits = {1, 0, 1, 0, 1, 0}
         Dim outputBase = 10
         Dim expected = {4, 2}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -43,7 +47,8 @@ Public Class AllYourBaseTests
         Dim digits = {4, 2}
         Dim outputBase = 2
         Dim expected = {1, 0, 1, 0, 1, 0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -52,7 +57,8 @@ Public Class AllYourBaseTests
         Dim digits = {1, 1, 2, 0}
         Dim outputBase = 16
         Dim expected = {2, 10}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -61,7 +67,8 @@ Public Class AllYourBaseTests
         Dim digits = {2, 10}
         Dim outputBase = 3
         Dim expected = {1, 1, 2, 0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -70,7 +77,8 @@ Public Class AllYourBaseTests
         Dim digits = {3, 46, 60}
         Dim outputBase = 73
         Dim expected = {6, 10, 45}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -79,7 +87,8 @@ Public Class AllYourBaseTests
         Dim digits = Array.Empty(Of Integer)()
         Dim outputBase = 10
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -88,7 +97,8 @@ Public Class AllYourBaseTests
         Dim digits = {0}
         Dim outputBase = 2
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -97,7 +107,8 @@ Public Class AllYourBaseTests
         Dim digits = {0, 0, 0}
         Dim outputBase = 2
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -106,7 +117,8 @@ Public Class AllYourBaseTests
         Dim digits = {0, 6, 0}
         Dim outputBase = 10
         Dim expected = {4, 2}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = Rebase(inputBase, digits, outputBase)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -114,7 +126,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 1
         Dim digits = {0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -122,7 +134,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 0
         Dim digits = Array.Empty(Of Integer)()
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -130,7 +142,7 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -138,7 +150,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, -1, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -146,7 +158,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 2, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -154,7 +166,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 0, 1, 0, 1, 0}
         Dim outputBase = 1
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -162,7 +174,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 10
         Dim digits = {7}
         Dim outputBase = 0
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -170,7 +182,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -178,6 +190,6 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 End Class

--- a/exercises/practice/all-your-base/AllYourBaseTests.vb
+++ b/exercises/practice/all-your-base/AllYourBaseTests.vb
@@ -7,7 +7,7 @@ Public Class AllYourBaseTests
         Dim digits = {1}
         Dim outputBase = 10
         Dim expected = {1}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -16,7 +16,7 @@ Public Class AllYourBaseTests
         Dim digits = {1, 0, 1}
         Dim outputBase = 10
         Dim expected = {5}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -25,7 +25,7 @@ Public Class AllYourBaseTests
         Dim digits = {5}
         Dim outputBase = 2
         Dim expected = {1, 0, 1}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -34,7 +34,7 @@ Public Class AllYourBaseTests
         Dim digits = {1, 0, 1, 0, 1, 0}
         Dim outputBase = 10
         Dim expected = {4, 2}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -43,7 +43,7 @@ Public Class AllYourBaseTests
         Dim digits = {4, 2}
         Dim outputBase = 2
         Dim expected = {1, 0, 1, 0, 1, 0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -52,7 +52,7 @@ Public Class AllYourBaseTests
         Dim digits = {1, 1, 2, 0}
         Dim outputBase = 16
         Dim expected = {2, 10}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -61,7 +61,7 @@ Public Class AllYourBaseTests
         Dim digits = {2, 10}
         Dim outputBase = 3
         Dim expected = {1, 1, 2, 0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -70,7 +70,7 @@ Public Class AllYourBaseTests
         Dim digits = {3, 46, 60}
         Dim outputBase = 73
         Dim expected = {6, 10, 45}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -79,7 +79,7 @@ Public Class AllYourBaseTests
         Dim digits = Array.Empty(Of Integer)()
         Dim outputBase = 10
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -88,7 +88,7 @@ Public Class AllYourBaseTests
         Dim digits = {0}
         Dim outputBase = 2
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -97,7 +97,7 @@ Public Class AllYourBaseTests
         Dim digits = {0, 0, 0}
         Dim outputBase = 2
         Dim expected = {0}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -106,7 +106,7 @@ Public Class AllYourBaseTests
         Dim digits = {0, 6, 0}
         Dim outputBase = 10
         Dim expected = {4, 2}
-        Assert.Equal(expected, Rebase(inputBase, digits, outputBase))
+        Assert.Equal(expected, Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -114,7 +114,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 1
         Dim digits = {0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -122,7 +122,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 0
         Dim digits = Array.Empty(Of Integer)()
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -130,7 +130,7 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -138,7 +138,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, -1, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -146,7 +146,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 2, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -154,7 +154,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 0, 1, 0, 1, 0}
         Dim outputBase = 1
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -162,7 +162,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 10
         Dim digits = {7}
         Dim outputBase = 0
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -170,7 +170,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -178,6 +178,6 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/allergies/Allergies.vbproj
+++ b/exercises/practice/allergies/Allergies.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/allergies/Allergies.vbproj
+++ b/exercises/practice/allergies/Allergies.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/anagram/Anagram.vbproj
+++ b/exercises/practice/anagram/Anagram.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/anagram/Anagram.vbproj
+++ b/exercises/practice/anagram/Anagram.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/anagram/AnagramTests.vb
+++ b/exercises/practice/anagram/AnagramTests.vb
@@ -5,74 +5,83 @@ Public Class AnagramTest
     <Fact>
     Public Sub NoMatches()
         Dim detector = New Anagram("diaper")
-        Dim words = New String() {"hello", "world", "zombies", "pants"}
-        Dim results = New String() {}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"hello", "world", "zombies", "pants"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub DetectSimpleAnagram()
         Dim detector = New Anagram("ant")
-        Dim words = New String() {"tan", "stand", "at"}
-        Dim results = New String() {"tan"}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"tan", "stand", "at"}
+        Dim expected = {"tan"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub DetectMultipleAnagrams()
         Dim detector = New Anagram("master")
-        Dim words = New String() {"stream", "pigeon", "maters"}
-        Dim results = New String() {"maters", "stream"}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"stream", "pigeon", "maters"}
+        Dim expected = {"maters", "stream"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub DoesNotConfuseDifferentDuplicates()
         Dim detector = New Anagram("galea")
-        Dim words = New String() {"eagle"}
-        Dim results = New String() {}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"eagle"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub IdenticalWordIsNotAnagram()
         Dim detector = New Anagram("corn")
-        Dim words = New String() {"corn", "dark", "Corn", "rank", "CORN", "cron",
+        Dim words = {"corn", "dark", "Corn", "rank", "CORN", "cron",
             "park"}
-        Dim results = New String() {"cron"}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim expected = {"cron"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub EliminateAnagramsWithSameChecksum()
         Dim detector = New Anagram("mass")
-        Dim words = New String() {"last"}
-        Dim results = New String(-1) {}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"last"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub EliminateAnagramSubsets()
         Dim detector = New Anagram("good")
-        Dim words = New String() {"dog", "goody"}
-        Dim results = New String(-1) {}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"dog", "goody"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub DetectAnagrams()
         Dim detector = New Anagram("allergy")
-        Dim words = New String() {"gallery", "ballerina", "regally", "clergy", "largely", "leading"}
-        Dim results = New String() {"gallery", "largely", "regally"}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"gallery", "ballerina", "regally", "clergy", "largely", "leading"}
+        Dim expected = {"gallery", "largely", "regally"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AnagramsAreCaseInsensitive()
         Dim detector = New Anagram("Orchestra")
-        Dim words = New String() {"cashregister", "Carthorse", "radishes"}
-        Dim results = New String() {"Carthorse"}
-        Assert.Equal(detector.Match(words).AsEnumerable(), results)
+        Dim words = {"cashregister", "Carthorse", "radishes"}
+        Dim expected = {"Carthorse"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
     End Sub
 
 End Class

--- a/exercises/practice/anagram/AnagramTests.vb
+++ b/exercises/practice/anagram/AnagramTests.vb
@@ -7,7 +7,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("diaper")
         Dim words = New String() {"hello", "world", "zombies", "pants"}
         Dim results = New String() {}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -15,7 +15,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("ant")
         Dim words = New String() {"tan", "stand", "at"}
         Dim results = New String() {"tan"}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -23,7 +23,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("master")
         Dim words = New String() {"stream", "pigeon", "maters"}
         Dim results = New String() {"maters", "stream"}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -31,7 +31,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("galea")
         Dim words = New String() {"eagle"}
         Dim results = New String() {}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -40,7 +40,7 @@ Public Class AnagramTest
         Dim words = New String() {"corn", "dark", "Corn", "rank", "CORN", "cron",
             "park"}
         Dim results = New String() {"cron"}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -48,7 +48,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("mass")
         Dim words = New String() {"last"}
         Dim results = New String(-1) {}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -56,7 +56,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("good")
         Dim words = New String() {"dog", "goody"}
         Dim results = New String(-1) {}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -64,7 +64,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("allergy")
         Dim words = New String() {"gallery", "ballerina", "regally", "clergy", "largely", "leading"}
         Dim results = New String() {"gallery", "largely", "regally"}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -72,7 +72,7 @@ Public Class AnagramTest
         Dim detector = New Anagram("Orchestra")
         Dim words = New String() {"cashregister", "Carthorse", "radishes"}
         Dim results = New String() {"Carthorse"}
-        Assert.Equal(detector.Match(words), results)
+        Assert.Equal(detector.Match(words).AsEnumerable(), results)
     End Sub
 
 End Class

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.vbproj
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.vbproj
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/atbash-cipher/AtbashCipher.vbproj
+++ b/exercises/practice/atbash-cipher/AtbashCipher.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/atbash-cipher/AtbashCipher.vbproj
+++ b/exercises/practice/atbash-cipher/AtbashCipher.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/bank-account/BankAccount.vbproj
+++ b/exercises/practice/bank-account/BankAccount.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/bank-account/BankAccount.vbproj
+++ b/exercises/practice/bank-account/BankAccount.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/beer-song/BeerSong.vbproj
+++ b/exercises/practice/beer-song/BeerSong.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/beer-song/BeerSong.vbproj
+++ b/exercises/practice/beer-song/BeerSong.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/binary-search/BinarySearch.vbproj
+++ b/exercises/practice/binary-search/BinarySearch.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/binary-search/BinarySearch.vbproj
+++ b/exercises/practice/binary-search/BinarySearch.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/binary/Binary.vbproj
+++ b/exercises/practice/binary/Binary.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/binary/Binary.vbproj
+++ b/exercises/practice/binary/Binary.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/bob/Bob.vbproj
+++ b/exercises/practice/bob/Bob.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/bob/Bob.vbproj
+++ b/exercises/practice/bob/Bob.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/bob/BobTests.vb
+++ b/exercises/practice/bob/BobTests.vb
@@ -5,86 +5,120 @@ Public Class BobTest
 
     <Fact>
     Public Sub StatingSomething()
-        Assert.Equal("Whatever.",  teenager.Hey("Tom-ay-to, tom-aaaah-to."), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("Tom-ay-to, tom-aaaah-to.")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Shouting()
+        Dim expected = "Whoa, chill out!"
+        Dim result as String = teenager.Hey("WATCH OUT!")
         Assert.Equal("Whoa, chill out!", teenager.Hey("WATCH OUT!"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingAQuestion()
-        Assert.Equal("Sure.", teenager.Hey("Does this cryogenic chamber make me look fat?"), false)
+        Dim expected = "Sure."
+        Dim result as String = teenager.Hey("Does this cryogenic chamber make me look fat?")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingANumericQuestion()
-        Assert.Equal("Sure.", teenager.Hey("You are, what, like 15?"), false)
+        Dim expected = "Sure."
+        Dim result as String = teenager.Hey("You are, what, like 15?")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub TalkingForcefully()
-        Assert.Equal("Whatever.", teenager.Hey("Let's go make out behind the gym!"), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("Let's go make out behind the gym!")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub UsingAcronymsInRegularSearch()
-        Assert.Equal("Whatever.", teenager.Hey("It's OK if you don't want to go to the DMV."), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("It's OK if you don't want to go to the DMV.")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ForcefulQuestions()
-        Assert.Equal("Calm down, I know what I'm doing!", teenager.Hey("WHAT THE HELL WERE YOU THINKING?"), false)
+        Dim expected = "Calm down, I know what I'm doing!"
+        Dim result as String = teenager.Hey("WHAT THE HELL WERE YOU THINKING?")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingNumbers()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("1, 2, 3 GO!"), false)
+        Dim expected = "Whoa, chill out!"
+        Dim result as String = teenager.Hey("1, 2, 3 GO!")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub OnlyNumbers()
-        Assert.Equal("Whatever.", teenager.Hey("1, 2, 3"), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("1, 2, 3")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub QuestionWithOnlyNumbers()
-        Assert.Equal("Sure.", teenager.Hey("4?"), false)
+        Dim expected = "Sure."
+        Dim result as String = teenager.Hey("4?")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithSpecialCharacters()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"), false)
+        Dim expected = "Whoa, chill out!"
+        Dim result as String = teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithNoExclamationMark()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("I HATE YOU"), false)
+        Dim expected = "Whoa, chill out!"
+        Dim result as String = teenager.Hey("I HATE YOU")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub StatementContainingQuestionMark()
-        Assert.Equal("Whatever.", teenager.Hey("Ending with ? means a question."), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("Ending with ? means a question.")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub PrattlingOn()
-        Assert.Equal("Sure.", teenager.Hey("Wait! Hang on. Are you going to be OK?"), false)
+        Dim expected = "Sure."
+        Dim result as String = teenager.Hey("Wait! Hang on. Are you going to be OK?")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Silence()
-        Assert.Equal("Fine. Be that way!", teenager.Hey(""), false)
+        Dim expected = "Fine. Be that way!"
+        Dim result as String = teenager.Hey("")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ProlongedSilence()
-        Assert.Equal("Fine. Be that way!", teenager.Hey("    "), false)
+        Dim expected = "Fine. Be that way!"
+        Dim result as String = teenager.Hey("    ")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub MultipleLineQuestion()
-        Assert.Equal("Whatever.", teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no"), false)
+        Dim expected = "Whatever."
+        Dim result as String = teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no")
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/bob/BobTests.vb
+++ b/exercises/practice/bob/BobTests.vb
@@ -1,90 +1,90 @@
-Imports XUnit
-
+Imports Xunit
 
 Public Class BobTest
     Private teenager = New Bob()
+
     <Fact>
     Public Sub StatingSomething()
-        Assert.Equal(teenager.Hey("Tom-ay-to, tom-aaaah-to."), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("Tom-ay-to, tom-aaaah-to."))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Shouting()
-        Assert.Equal(teenager.Hey("WATCH OUT!"), "Whoa, chill out!")
+        Assert.Equal("Whoa, chill out!", teenager.Hey("WATCH OUT!"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingAQuestion()
-        Assert.Equal(teenager.Hey("Does this cryogenic chamber make me look fat?"), "Sure.")
+        Assert.Equal("Sure.", teenager.Hey("Does this cryogenic chamber make me look fat?"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingANumericQuestion()
-        Assert.Equal(teenager.Hey("You are, what, like 15?"), "Sure.")
+        Assert.Equal("Sure.", teenager.Hey("You are, what, like 15?"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub TalkingForcefully()
-        Assert.Equal(teenager.Hey("Let's go make out behind the gym!"), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("Let's go make out behind the gym!"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub UsingAcronymsInRegularSearch()
-        Assert.Equal(teenager.Hey("It's OK if you don't want to go to the DMV."), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("It's OK if you don't want to go to the DMV."))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ForcefulQuestions()
-        Assert.Equal(teenager.Hey("WHAT THE HELL WERE YOU THINKING?"), "Calm down, I know what I'm doing!")
+        Assert.Equal("Calm down, I know what I'm doing!", teenager.Hey("WHAT THE HELL WERE YOU THINKING?"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingNumbers()
-        Assert.Equal(teenager.Hey("1, 2, 3 GO!"), "Whoa, chill out!")
+        Assert.Equal("Whoa, chill out!", teenager.Hey("1, 2, 3 GO!"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub OnlyNumbers()
-        Assert.Equal(teenager.Hey("1, 2, 3"), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("1, 2, 3"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub QuestionWithOnlyNumbers()
-        Assert.Equal(teenager.Hey("4?"), "Sure.")
+        Assert.Equal("Sure.", teenager.Hey("4?"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithSpecialCharacters()
-        Assert.Equal(teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"), "Whoa, chill out!")
+        Assert.Equal("Whoa, chill out!", teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithNoExclamationMark()
-        Assert.Equal(teenager.Hey("I HATE YOU"), "Whoa, chill out!")
+        Assert.Equal("Whoa, chill out!", teenager.Hey("I HATE YOU"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub StatementContainingQuestionMark()
-        Assert.Equal(teenager.Hey("Ending with ? means a question."), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("Ending with ? means a question."))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub PrattlingOn()
-        Assert.Equal(teenager.Hey("Wait! Hang on. Are you going to be OK?"), "Sure.")
+        Assert.Equal("Sure.", teenager.Hey("Wait! Hang on. Are you going to be OK?"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Silence()
-        Assert.Equal(teenager.Hey(""), "Fine. Be that way!")
+        Assert.Equal("Fine. Be that way!", teenager.Hey(""))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ProlongedSilence()
-        Assert.Equal(teenager.Hey("    "), "Fine. Be that way!")
+        Assert.Equal("Fine. Be that way!", teenager.Hey("    "))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub MultipleLineQuestion()
-        Assert.Equal(teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no"), "Whatever.")
+        Assert.Equal("Whatever.", teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no"))
     End Sub
 End Class

--- a/exercises/practice/bob/BobTests.vb
+++ b/exercises/practice/bob/BobTests.vb
@@ -5,86 +5,86 @@ Public Class BobTest
 
     <Fact>
     Public Sub StatingSomething()
-        Assert.Equal("Whatever.", teenager.Hey("Tom-ay-to, tom-aaaah-to."))
+        Assert.Equal("Whatever.",  teenager.Hey("Tom-ay-to, tom-aaaah-to."), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Shouting()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("WATCH OUT!"))
+        Assert.Equal("Whoa, chill out!", teenager.Hey("WATCH OUT!"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingAQuestion()
-        Assert.Equal("Sure.", teenager.Hey("Does this cryogenic chamber make me look fat?"))
+        Assert.Equal("Sure.", teenager.Hey("Does this cryogenic chamber make me look fat?"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AskingANumericQuestion()
-        Assert.Equal("Sure.", teenager.Hey("You are, what, like 15?"))
+        Assert.Equal("Sure.", teenager.Hey("You are, what, like 15?"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub TalkingForcefully()
-        Assert.Equal("Whatever.", teenager.Hey("Let's go make out behind the gym!"))
+        Assert.Equal("Whatever.", teenager.Hey("Let's go make out behind the gym!"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub UsingAcronymsInRegularSearch()
-        Assert.Equal("Whatever.", teenager.Hey("It's OK if you don't want to go to the DMV."))
+        Assert.Equal("Whatever.", teenager.Hey("It's OK if you don't want to go to the DMV."), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ForcefulQuestions()
-        Assert.Equal("Calm down, I know what I'm doing!", teenager.Hey("WHAT THE HELL WERE YOU THINKING?"))
+        Assert.Equal("Calm down, I know what I'm doing!", teenager.Hey("WHAT THE HELL WERE YOU THINKING?"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingNumbers()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("1, 2, 3 GO!"))
+        Assert.Equal("Whoa, chill out!", teenager.Hey("1, 2, 3 GO!"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub OnlyNumbers()
-        Assert.Equal("Whatever.", teenager.Hey("1, 2, 3"))
+        Assert.Equal("Whatever.", teenager.Hey("1, 2, 3"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub QuestionWithOnlyNumbers()
-        Assert.Equal("Sure.", teenager.Hey("4?"))
+        Assert.Equal("Sure.", teenager.Hey("4?"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithSpecialCharacters()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"))
+        Assert.Equal("Whoa, chill out!", teenager.Hey("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ShoutingWithNoExclamationMark()
-        Assert.Equal("Whoa, chill out!", teenager.Hey("I HATE YOU"))
+        Assert.Equal("Whoa, chill out!", teenager.Hey("I HATE YOU"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub StatementContainingQuestionMark()
-        Assert.Equal("Whatever.", teenager.Hey("Ending with ? means a question."))
+        Assert.Equal("Whatever.", teenager.Hey("Ending with ? means a question."), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub PrattlingOn()
-        Assert.Equal("Sure.", teenager.Hey("Wait! Hang on. Are you going to be OK?"))
+        Assert.Equal("Sure.", teenager.Hey("Wait! Hang on. Are you going to be OK?"), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Silence()
-        Assert.Equal("Fine. Be that way!", teenager.Hey(""))
+        Assert.Equal("Fine. Be that way!", teenager.Hey(""), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ProlongedSilence()
-        Assert.Equal("Fine. Be that way!", teenager.Hey("    "))
+        Assert.Equal("Fine. Be that way!", teenager.Hey("    "), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub MultipleLineQuestion()
-        Assert.Equal("Whatever.", teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no"))
+        Assert.Equal("Whatever.", teenager.Hey("Does this cryogenic chamber make me look fat?" & vbLf & "no"), false)
     End Sub
 End Class

--- a/exercises/practice/book-store/BookStore.vbproj
+++ b/exercises/practice/book-store/BookStore.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/book-store/BookStore.vbproj
+++ b/exercises/practice/book-store/BookStore.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/bottle-song/BottleSong.vbproj
+++ b/exercises/practice/bottle-song/BottleSong.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/bottle-song/BottleSong.vbproj
+++ b/exercises/practice/bottle-song/BottleSong.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/bowling/Bowling.vbproj
+++ b/exercises/practice/bowling/Bowling.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/bowling/Bowling.vbproj
+++ b/exercises/practice/bowling/Bowling.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/change/Change.vbproj
+++ b/exercises/practice/change/Change.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/change/Change.vbproj
+++ b/exercises/practice/change/Change.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/change/ChangeTests.vb
+++ b/exercises/practice/change/ChangeTests.vb
@@ -7,7 +7,8 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25}
         Dim target = 1
         Dim expected = {1}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -15,7 +16,8 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25, 100}
         Dim target = 25
         Dim expected = {25}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -23,7 +25,8 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25, 100}
         Dim target = 15
         Dim expected = {5, 10}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -31,7 +34,8 @@ Public Class ChangeTests
         Dim coins = {1, 4, 15, 20, 50}
         Dim target = 23
         Dim expected = {4, 4, 15}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -39,7 +43,8 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 21, 25}
         Dim target = 63
         Dim expected = {21, 21, 21}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -47,7 +52,8 @@ Public Class ChangeTests
         Dim coins = {1, 2, 5, 10, 20, 50, 100}
         Dim target = 999
         Dim expected = {2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -55,7 +61,8 @@ Public Class ChangeTests
         Dim coins = {2, 5, 10, 20, 50}
         Dim target = 21
         Dim expected = {2, 2, 2, 5, 10}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -63,34 +70,35 @@ Public Class ChangeTests
         Dim coins = {4, 5}
         Dim target = 27
         Dim expected = {4, 4, 4, 5, 5, 5}
-        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
+        Dim result as IEnumerable(Of Integer) = FindFewestCoins(coins, target)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_coins_make_0_change()
         Dim coins = {1, 5, 10, 21, 25}
         Dim target = 0
-        Assert.Empty(FindFewestCoins(coins, target).AsEnumerable())
+        Assert.Empty(FindFewestCoins(coins, target))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Error_testing_for_change_smaller_than_the_smallest_of_coins()
         Dim coins = {5, 10}
         Dim target = 3
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Error_if_no_combination_can_add_up_to_target()
         Dim coins = {5, 10}
         Dim target = 94
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cannot_find_negative_change_values()
         Dim coins = {1, 2, 5}
         Dim target = -5
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
     End Sub
 End Class

--- a/exercises/practice/change/ChangeTests.vb
+++ b/exercises/practice/change/ChangeTests.vb
@@ -7,7 +7,7 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25}
         Dim target = 1
         Dim expected = {1}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -15,7 +15,7 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25, 100}
         Dim target = 25
         Dim expected = {25}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -23,7 +23,7 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 25, 100}
         Dim target = 15
         Dim expected = {5, 10}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -31,7 +31,7 @@ Public Class ChangeTests
         Dim coins = {1, 4, 15, 20, 50}
         Dim target = 23
         Dim expected = {4, 4, 15}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -39,7 +39,7 @@ Public Class ChangeTests
         Dim coins = {1, 5, 10, 21, 25}
         Dim target = 63
         Dim expected = {21, 21, 21}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -47,7 +47,7 @@ Public Class ChangeTests
         Dim coins = {1, 2, 5, 10, 20, 50, 100}
         Dim target = 999
         Dim expected = {2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -55,7 +55,7 @@ Public Class ChangeTests
         Dim coins = {2, 5, 10, 20, 50}
         Dim target = 21
         Dim expected = {2, 2, 2, 5, 10}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -63,34 +63,34 @@ Public Class ChangeTests
         Dim coins = {4, 5}
         Dim target = 27
         Dim expected = {4, 4, 4, 5, 5, 5}
-        Assert.Equal(expected, FindFewestCoins(coins, target))
+        Assert.Equal(expected, FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_coins_make_0_change()
         Dim coins = {1, 5, 10, 21, 25}
         Dim target = 0
-        Assert.Empty(FindFewestCoins(coins, target))
+        Assert.Empty(FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Error_testing_for_change_smaller_than_the_smallest_of_coins()
         Dim coins = {5, 10}
         Dim target = 3
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Error_if_no_combination_can_add_up_to_target()
         Dim coins = {5, 10}
         Dim target = 94
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cannot_find_negative_change_values()
         Dim coins = {1, 2, 5}
         Dim target = -5
-        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target))
+        Assert.Throws(Of ArgumentException)(Function() FindFewestCoins(coins, target).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/circular-buffer/CircularBuffer.vbproj
+++ b/exercises/practice/circular-buffer/CircularBuffer.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/circular-buffer/CircularBuffer.vbproj
+++ b/exercises/practice/circular-buffer/CircularBuffer.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/clock/Clock.vbproj
+++ b/exercises/practice/clock/Clock.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/clock/Clock.vbproj
+++ b/exercises/practice/clock/Clock.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.vbproj
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.vbproj
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/crypto-square/CryptoSquare.vbproj
+++ b/exercises/practice/crypto-square/CryptoSquare.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/crypto-square/CryptoSquare.vbproj
+++ b/exercises/practice/crypto-square/CryptoSquare.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/darts/Darts.vbproj
+++ b/exercises/practice/darts/Darts.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/darts/Darts.vbproj
+++ b/exercises/practice/darts/Darts.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.vbproj
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.vbproj
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/diffie-hellman/DiffieHellman.vbproj
+++ b/exercises/practice/diffie-hellman/DiffieHellman.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/diffie-hellman/DiffieHellman.vbproj
+++ b/exercises/practice/diffie-hellman/DiffieHellman.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/dnd-character/DndCharacter.vbproj
+++ b/exercises/practice/dnd-character/DndCharacter.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/dnd-character/DndCharacter.vbproj
+++ b/exercises/practice/dnd-character/DndCharacter.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/error-handling/ErrorHandling.vbproj
+++ b/exercises/practice/error-handling/ErrorHandling.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/error-handling/ErrorHandling.vbproj
+++ b/exercises/practice/error-handling/ErrorHandling.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/etl/Etl.vbproj
+++ b/exercises/practice/etl/Etl.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/etl/Etl.vbproj
+++ b/exercises/practice/etl/Etl.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/flatten-array/FlattenArray.vbproj
+++ b/exercises/practice/flatten-array/FlattenArray.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/flatten-array/FlattenArray.vbproj
+++ b/exercises/practice/flatten-array/FlattenArray.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/food-chain/FoodChain.vbproj
+++ b/exercises/practice/food-chain/FoodChain.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/food-chain/FoodChain.vbproj
+++ b/exercises/practice/food-chain/FoodChain.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/gigasecond/Gigasecond.vbproj
+++ b/exercises/practice/gigasecond/Gigasecond.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/gigasecond/Gigasecond.vbproj
+++ b/exercises/practice/gigasecond/Gigasecond.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/grade-school/GradeSchool.vbproj
+++ b/exercises/practice/grade-school/GradeSchool.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/grade-school/GradeSchool.vbproj
+++ b/exercises/practice/grade-school/GradeSchool.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/grains/Grains.vbproj
+++ b/exercises/practice/grains/Grains.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/grains/Grains.vbproj
+++ b/exercises/practice/grains/Grains.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/grep/Grep.vbproj
+++ b/exercises/practice/grep/Grep.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/grep/Grep.vbproj
+++ b/exercises/practice/grep/Grep.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/hamming/Hamming.vbproj
+++ b/exercises/practice/hamming/Hamming.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/hamming/Hamming.vbproj
+++ b/exercises/practice/hamming/Hamming.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/hello-world/HelloWorld.vbproj
+++ b/exercises/practice/hello-world/HelloWorld.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/hello-world/HelloWorld.vbproj
+++ b/exercises/practice/hello-world/HelloWorld.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/high-scores/HighScores.vbproj
+++ b/exercises/practice/high-scores/HighScores.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/high-scores/HighScores.vbproj
+++ b/exercises/practice/high-scores/HighScores.vbproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/house/House.vbproj
+++ b/exercises/practice/house/House.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/house/House.vbproj
+++ b/exercises/practice/house/House.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/isbn-verifier/IsbnVerifier.vbproj
+++ b/exercises/practice/isbn-verifier/IsbnVerifier.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/isbn-verifier/IsbnVerifier.vbproj
+++ b/exercises/practice/isbn-verifier/IsbnVerifier.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/isogram/Isogram.vbproj
+++ b/exercises/practice/isogram/Isogram.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/isogram/Isogram.vbproj
+++ b/exercises/practice/isogram/Isogram.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.vbproj
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.vbproj
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/leap/Leap.vbproj
+++ b/exercises/practice/leap/Leap.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/leap/Leap.vbproj
+++ b/exercises/practice/leap/Leap.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/ledger/Ledger.vbproj
+++ b/exercises/practice/ledger/Ledger.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/ledger/Ledger.vbproj
+++ b/exercises/practice/ledger/Ledger.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/linked-list/LinkedList.vbproj
+++ b/exercises/practice/linked-list/LinkedList.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/linked-list/LinkedList.vbproj
+++ b/exercises/practice/linked-list/LinkedList.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/list-ops/ListOps.vbproj
+++ b/exercises/practice/list-ops/ListOps.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/list-ops/ListOps.vbproj
+++ b/exercises/practice/list-ops/ListOps.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/luhn/Luhn.vbproj
+++ b/exercises/practice/luhn/Luhn.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/luhn/Luhn.vbproj
+++ b/exercises/practice/luhn/Luhn.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/matching-brackets/MatchingBrackets.vbproj
+++ b/exercises/practice/matching-brackets/MatchingBrackets.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/matching-brackets/MatchingBrackets.vbproj
+++ b/exercises/practice/matching-brackets/MatchingBrackets.vbproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/matrix/Matrix.vbproj
+++ b/exercises/practice/matrix/Matrix.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/matrix/Matrix.vbproj
+++ b/exercises/practice/matrix/Matrix.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/matrix/MatrixTests.vb
+++ b/exercises/practice/matrix/MatrixTests.vb
@@ -4,48 +4,64 @@ Public Class MatrixTests
     <Fact>
     Public Sub Extract_row_from_one_number_matrix()
         Dim sut = New Matrix("1")
-        Assert.Equal({1}, sut.Row(1).AsEnumerable())
+        Dim expected = {1}
+        Dim result as IEnumerable(Of Integer) = sut.Row(1)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_row()
         Dim sut = New Matrix("1 2" & vbLf & "3 4")
-        Assert.Equal({3, 4}, sut.Row(2).AsEnumerable())
+        Dim expected = {3, 4}
+        Dim result as IEnumerable(Of Integer) = sut.Row(2)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_row_where_numbers_have_different_widths()
         Dim sut = New Matrix("1 2" & vbLf & "10 20")
-        Assert.Equal({10, 20}, sut.Row(2).AsEnumerable())
+        Dim expected = {10, 20}
+        Dim result as IEnumerable(Of Integer) = sut.Row(2)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_row_from_non_square_matrix_with_no_corresponding_column()
         Dim sut = New Matrix("1 2 3" & vbLf & "4 5 6" & vbLf & "7 8 9" & vbLf & "8 7 6")
-        Assert.Equal({8, 7, 6}, sut.Row(4).AsEnumerable())
+        Dim expected = {8, 7, 6}
+        Dim result as IEnumerable(Of Integer) = sut.Row(4)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_column_from_one_number_matrix()
         Dim sut = New Matrix("1")
-        Assert.Equal({1}, sut.Column(1).AsEnumerable())
+        Dim expected = {1}
+        Dim result as IEnumerable(Of Integer) = sut.Column(1)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_column()
         Dim sut = New Matrix("1 2 3" & vbLf & "4 5 6" & vbLf & "7 8 9")
-        Assert.Equal({3, 6, 9}, sut.Column(3).AsEnumerable())
+        Dim expected = {3, 6, 9}
+        Dim result as IEnumerable(Of Integer) = sut.Column(3)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_column_from_non_square_matrix_with_no_corresponding_row()
         Dim sut = New Matrix("1 2 3 4" & vbLf & "5 6 7 8" & vbLf & "9 8 7 6")
-        Assert.Equal({4, 8, 6}, sut.Column(4).AsEnumerable())
+        Dim expected = {4, 8, 6}
+        Dim result as IEnumerable(Of Integer) = sut.Column(4)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_column_where_numbers_have_different_widths()
         Dim sut = New Matrix("89 1903 3" & vbLf & "18 3 1" & vbLf & "9 4 800")
-        Assert.Equal({1903, 3, 4}, sut.Column(2).AsEnumerable())
+        Dim expected = {1903, 3, 4}
+        Dim result as IEnumerable(Of Integer) = sut.Column(2)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/matrix/MatrixTests.vb
+++ b/exercises/practice/matrix/MatrixTests.vb
@@ -4,48 +4,48 @@ Public Class MatrixTests
     <Fact>
     Public Sub Extract_row_from_one_number_matrix()
         Dim sut = New Matrix("1")
-        Assert.Equal({1}, sut.Row(1))
+        Assert.Equal({1}, sut.Row(1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_row()
         Dim sut = New Matrix("1 2" & vbLf & "3 4")
-        Assert.Equal({3, 4}, sut.Row(2))
+        Assert.Equal({3, 4}, sut.Row(2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_row_where_numbers_have_different_widths()
         Dim sut = New Matrix("1 2" & vbLf & "10 20")
-        Assert.Equal({10, 20}, sut.Row(2))
+        Assert.Equal({10, 20}, sut.Row(2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_row_from_non_square_matrix_with_no_corresponding_column()
         Dim sut = New Matrix("1 2 3" & vbLf & "4 5 6" & vbLf & "7 8 9" & vbLf & "8 7 6")
-        Assert.Equal({8, 7, 6}, sut.Row(4))
+        Assert.Equal({8, 7, 6}, sut.Row(4).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_column_from_one_number_matrix()
         Dim sut = New Matrix("1")
-        Assert.Equal({1}, sut.Column(1))
+        Assert.Equal({1}, sut.Column(1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_column()
         Dim sut = New Matrix("1 2 3" & vbLf & "4 5 6" & vbLf & "7 8 9")
-        Assert.Equal({3, 6, 9}, sut.Column(3))
+        Assert.Equal({3, 6, 9}, sut.Column(3).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Can_extract_column_from_non_square_matrix_with_no_corresponding_row()
         Dim sut = New Matrix("1 2 3 4" & vbLf & "5 6 7 8" & vbLf & "9 8 7 6")
-        Assert.Equal({4, 8, 6}, sut.Column(4))
+        Assert.Equal({4, 8, 6}, sut.Column(4).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Extract_column_where_numbers_have_different_widths()
         Dim sut = New Matrix("89 1903 3" & vbLf & "18 3 1" & vbLf & "9 4 800")
-        Assert.Equal({1903, 3, 4}, sut.Column(2))
+        Assert.Equal({1903, 3, 4}, sut.Column(2).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/meetup/Meetup.vbproj
+++ b/exercises/practice/meetup/Meetup.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/meetup/Meetup.vbproj
+++ b/exercises/practice/meetup/Meetup.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/minesweeper/Minesweeper.vbproj
+++ b/exercises/practice/minesweeper/Minesweeper.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/minesweeper/Minesweeper.vbproj
+++ b/exercises/practice/minesweeper/Minesweeper.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/minesweeper/MinesweeperTests.vb
+++ b/exercises/practice/minesweeper/MinesweeperTests.vb
@@ -6,83 +6,83 @@ Public Class MinesweeperTests
     Public Sub No_rows()
         Dim minefield = Array.Empty(Of String)()
         Dim expected = Array.Empty(Of String)()
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_columns()
         Dim minefield = {""}
         Dim expected = {""}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_mines()
         Dim minefield = {"   ", "   ", "   "}
         Dim expected = {"   ", "   ", "   "}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minefield_with_only_mines()
         Dim minefield = {"***", "***", "***"}
         Dim expected = {"***", "***", "***"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Mine_surrounded_by_spaces()
         Dim minefield = {"   ", " * ", "   "}
         Dim expected = {"111", "1*1", "111"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Space_surrounded_by_mines()
         Dim minefield = {"***", "* *", "***"}
         Dim expected = {"***", "*8*", "***"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Horizontal_line()
         Dim minefield = {" * * "}
         Dim expected = {"1*2*1"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Horizontal_line_mines_at_edges()
         Dim minefield = {"*   *"}
         Dim expected = {"*1 1*"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Vertical_line()
         Dim minefield = {" ", "*", " ", "*", " "}
         Dim expected = {"1", "*", "2", "*", "1"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Vertical_line_mines_at_edges()
         Dim minefield = {"*", " ", " ", " ", "*"}
         Dim expected = {"*", "1", " ", "1", "*"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cross()
         Dim minefield = {"  *  ", "  *  ", "*****", "  *  ", "  *  "}
         Dim expected = {" 2*2 ", "25*52", "*****", "25*52", " 2*2 "}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Large_minefield()
         Dim minefield = {" *  * ", "  *   ", "    * ", "   * *", " *  * ", "      "}
         Dim expected = {"1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield))
+        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/minesweeper/MinesweeperTests.vb
+++ b/exercises/practice/minesweeper/MinesweeperTests.vb
@@ -6,83 +6,95 @@ Public Class MinesweeperTests
     Public Sub No_rows()
         Dim minefield = Array.Empty(Of String)()
         Dim expected = Array.Empty(Of String)()
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_columns()
         Dim minefield = {""}
         Dim expected = {""}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_mines()
         Dim minefield = {"   ", "   ", "   "}
         Dim expected = {"   ", "   ", "   "}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minefield_with_only_mines()
         Dim minefield = {"***", "***", "***"}
         Dim expected = {"***", "***", "***"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Mine_surrounded_by_spaces()
         Dim minefield = {"   ", " * ", "   "}
         Dim expected = {"111", "1*1", "111"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Space_surrounded_by_mines()
         Dim minefield = {"***", "* *", "***"}
         Dim expected = {"***", "*8*", "***"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Horizontal_line()
         Dim minefield = {" * * "}
         Dim expected = {"1*2*1"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Horizontal_line_mines_at_edges()
         Dim minefield = {"*   *"}
         Dim expected = {"*1 1*"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Vertical_line()
         Dim minefield = {" ", "*", " ", "*", " "}
         Dim expected = {"1", "*", "2", "*", "1"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Vertical_line_mines_at_edges()
         Dim minefield = {"*", " ", " ", " ", "*"}
         Dim expected = {"*", "1", " ", "1", "*"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cross()
         Dim minefield = {"  *  ", "  *  ", "*****", "  *  ", "  *  "}
         Dim expected = {" 2*2 ", "25*52", "*****", "25*52", " 2*2 "}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Large_minefield()
         Dim minefield = {" *  * ", "  *   ", "    * ", "   * *", " *  * ", "      "}
         Dim expected = {"1*22*1", "12*322", " 123*2", "112*4*", "1*22*2", "111111"}
-        Assert.Equal(expected, Minesweeper.Annotate(minefield).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Minesweeper.Annotate(minefield)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/nucleotide-count/NucleotideCount.vbproj
+++ b/exercises/practice/nucleotide-count/NucleotideCount.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/nucleotide-count/NucleotideCount.vbproj
+++ b/exercises/practice/nucleotide-count/NucleotideCount.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/ocr-numbers/OcrNumbers.vbproj
+++ b/exercises/practice/ocr-numbers/OcrNumbers.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/ocr-numbers/OcrNumbers.vbproj
+++ b/exercises/practice/ocr-numbers/OcrNumbers.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/pangram/Pangram.vbproj
+++ b/exercises/practice/pangram/Pangram.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/pangram/Pangram.vbproj
+++ b/exercises/practice/pangram/Pangram.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/parallel-letter-frequency/ParallelLetterFrequency.vbproj
+++ b/exercises/practice/parallel-letter-frequency/ParallelLetterFrequency.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/parallel-letter-frequency/ParallelLetterFrequency.vbproj
+++ b/exercises/practice/parallel-letter-frequency/ParallelLetterFrequency.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/perfect-numbers/PerfectNumbers.vbproj
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/perfect-numbers/PerfectNumbers.vbproj
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.vbproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/phone-number/PhoneNumber.vbproj
+++ b/exercises/practice/phone-number/PhoneNumber.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/phone-number/PhoneNumber.vbproj
+++ b/exercises/practice/phone-number/PhoneNumber.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/pig-latin/PigLatin.vbproj
+++ b/exercises/practice/pig-latin/PigLatin.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/pig-latin/PigLatin.vbproj
+++ b/exercises/practice/pig-latin/PigLatin.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/poker/Poker.vbproj
+++ b/exercises/practice/poker/Poker.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/poker/Poker.vbproj
+++ b/exercises/practice/poker/Poker.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/prime-factors/PrimeFactors.vbproj
+++ b/exercises/practice/prime-factors/PrimeFactors.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/prime-factors/PrimeFactors.vbproj
+++ b/exercises/practice/prime-factors/PrimeFactors.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/prime-factors/PrimeFactorsTests.vb
+++ b/exercises/practice/prime-factors/PrimeFactorsTests.vb
@@ -3,61 +3,61 @@ Imports Xunit
 Public Class PrimeFactorsTests
     <Fact>
     Public Sub No_factors()
-        Assert.Empty(PrimeFactors.Factors(1L))
+        Assert.Empty(PrimeFactors.Factors(1L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Prime_number()
-        Assert.Equal({2L}, PrimeFactors.Factors(2L))
+        Assert.Equal({2L}, PrimeFactors.Factors(2L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Another_prime_number()
-        Assert.Equal({3L}, PrimeFactors.Factors(3L))
+        Assert.Equal({3L}, PrimeFactors.Factors(3L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Square_of_a_prime()
-        Assert.Equal({3L, 3L}, PrimeFactors.Factors(9L))
+        Assert.Equal({3L, 3L}, PrimeFactors.Factors(9L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_first_prime()
-        Assert.Equal({2L, 2L}, PrimeFactors.Factors(4L))
+        Assert.Equal({2L, 2L}, PrimeFactors.Factors(4L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cube_of_a_prime()
-        Assert.Equal({2L, 2L, 2L}, PrimeFactors.Factors(8L))
+        Assert.Equal({2L, 2L, 2L}, PrimeFactors.Factors(8L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_second_prime()
-        Assert.Equal({3L, 3L, 3L}, PrimeFactors.Factors(27L))
+        Assert.Equal({3L, 3L, 3L}, PrimeFactors.Factors(27L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_third_prime()
-        Assert.Equal({5L, 5L, 5L, 5L}, PrimeFactors.Factors(625L))
+        Assert.Equal({5L, 5L, 5L, 5L}, PrimeFactors.Factors(625L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_first_and_second_prime()
-        Assert.Equal({2L, 3L}, PrimeFactors.Factors(6L))
+        Assert.Equal({2L, 3L}, PrimeFactors.Factors(6L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_primes_and_non_primes()
-        Assert.Equal({2L, 2L, 3L}, PrimeFactors.Factors(12L))
+        Assert.Equal({2L, 2L, 3L}, PrimeFactors.Factors(12L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_primes()
-        Assert.Equal({5L, 17L, 23L, 461L}, PrimeFactors.Factors(901255L))
+        Assert.Equal({5L, 17L, 23L, 461L}, PrimeFactors.Factors(901255L).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Factors_include_a_large_prime()
-        Assert.Equal({11L, 9539L, 894119L}, PrimeFactors.Factors(93819012551L))
+        Assert.Equal({11L, 9539L, 894119L}, PrimeFactors.Factors(93819012551L).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/prime-factors/PrimeFactorsTests.vb
+++ b/exercises/practice/prime-factors/PrimeFactorsTests.vb
@@ -3,61 +3,97 @@ Imports Xunit
 Public Class PrimeFactorsTests
     <Fact>
     Public Sub No_factors()
-        Assert.Empty(PrimeFactors.Factors(1L).AsEnumerable())
+        dim number = 1L
+        dim expected = Array.Empty(Of Long)()
+        dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Prime_number()
-        Assert.Equal({2L}, PrimeFactors.Factors(2L).AsEnumerable())
+        dim number = 2L
+        dim expected = {2L}
+        dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Another_prime_number()
-        Assert.Equal({3L}, PrimeFactors.Factors(3L).AsEnumerable())
+        dim number = 3L
+        dim expected = {3L}
+        dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Square_of_a_prime()
-        Assert.Equal({3L, 3L}, PrimeFactors.Factors(9L).AsEnumerable())
+        Dim number = 9L
+        Dim expected = {3L, 3L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_first_prime()
-        Assert.Equal({2L, 2L}, PrimeFactors.Factors(4L).AsEnumerable())
+        Dim number = 4L
+        Dim expected = {2L, 2L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cube_of_a_prime()
-        Assert.Equal({2L, 2L, 2L}, PrimeFactors.Factors(8L).AsEnumerable())
+        Dim number = 8L
+        Dim expected = {2L, 2L, 2L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_second_prime()
-        Assert.Equal({3L, 3L, 3L}, PrimeFactors.Factors(27L).AsEnumerable())
+        Dim number = 27L
+        Dim expected = {3L, 3L, 3L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_third_prime()
-        Assert.Equal({5L, 5L, 5L, 5L}, PrimeFactors.Factors(625L).AsEnumerable())
+        Dim number = 625L
+        Dim expected = {5L, 5L, 5L, 5L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_first_and_second_prime()
-        Assert.Equal({2L, 3L}, PrimeFactors.Factors(6L).AsEnumerable())
+        Dim number = 6L
+        Dim expected = {2L, 3L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_primes_and_non_primes()
-        Assert.Equal({2L, 2L, 3L}, PrimeFactors.Factors(12L).AsEnumerable())
+        Dim number = 12L
+        Dim expected = {2L, 2L, 3L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Product_of_primes()
-        Assert.Equal({5L, 17L, 23L, 461L}, PrimeFactors.Factors(901255L).AsEnumerable())
+        Dim number = 901255L
+        Dim expected = {5L, 17L, 23L, 461L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Factors_include_a_large_prime()
-        Assert.Equal({11L, 9539L, 894119L}, PrimeFactors.Factors(93819012551L).AsEnumerable())
+        Dim number = 93819012551L
+        Dim expected = {11L, 9539L, 894119L}
+        Dim result as IEnumerable(of Long) = PrimeFactors.Factors(number)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/protein-translation/ProteinTranslation.vbproj
+++ b/exercises/practice/protein-translation/ProteinTranslation.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/protein-translation/ProteinTranslation.vbproj
+++ b/exercises/practice/protein-translation/ProteinTranslation.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/protein-translation/ProteinTranslationTests.vb
+++ b/exercises/practice/protein-translation/ProteinTranslationTests.vb
@@ -8,126 +8,189 @@ Public Class ProteinTranslationTests
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Methionine_rna_sequence()
-        Assert.Equal({"Methionine"}, Proteins("AUG").AsEnumerable())
+        Dim strand = "AUG"
+        Dim expected = {"Methionine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phenylalanine_rna_sequence_1()
-        Assert.Equal({"Phenylalanine"}, Proteins("UUU").AsEnumerable())
+        Dim strand = "UUU"
+        Dim expected = {"Phenylalanine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phenylalanine_rna_sequence_2()
-        Assert.Equal({"Phenylalanine"}, Proteins("UUC").AsEnumerable())
+        Dim strand = "UUC"
+        Dim expected = {"Phenylalanine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Leucine_rna_sequence_1()
-        Assert.Equal({"Leucine"}, Proteins("UUA").AsEnumerable())
+        Dim strand = "UUA"
+        Dim expected = {"Leucine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Leucine_rna_sequence_2()
-        Assert.Equal({"Leucine"}, Proteins("UUG").AsEnumerable())
+        Dim strand = "UUG"
+        Dim expected = {"Leucine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_1()
-        Assert.Equal({"Serine"}, Proteins("UCU").AsEnumerable())
+        Dim strand = "UCU"
+        Dim expected = {"Serine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_2()
-        Assert.Equal({"Serine"}, Proteins("UCC").AsEnumerable())
+        Dim strand = "UCC"
+        Dim expected = {"Serine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_3()
-        Assert.Equal({"Serine"}, Proteins("UCA").AsEnumerable())
+        Dim strand = "UCA"
+        Dim expected = {"Serine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_4()
-        Assert.Equal({"Serine"}, Proteins("UCG").AsEnumerable())
+        Dim strand = "UCG"
+        Dim expected = {"Serine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tyrosine_rna_sequence_1()
-        Assert.Equal({"Tyrosine"}, Proteins("UAU").AsEnumerable())
+        Dim strand = "UAU"
+        Dim expected = {"Tyrosine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tyrosine_rna_sequence_2()
-        Assert.Equal({"Tyrosine"}, Proteins("UAC").AsEnumerable())
+        Dim strand = "UAC"
+        Dim expected = {"Tyrosine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cysteine_rna_sequence_1()
-        Assert.Equal({"Cysteine"}, Proteins("UGU").AsEnumerable())
+        Dim strand = "UGU"
+        Dim expected = {"Cysteine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cysteine_rna_sequence_2()
-        Assert.Equal({"Cysteine"}, Proteins("UGC").AsEnumerable())
+        Dim strand = "UGC"
+        Dim expected = {"Cysteine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tryptophan_rna_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGG").AsEnumerable())
+        Dim strand = "UGG"
+        Dim expected = {"Tryptophan"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_1()
-        Assert.Empty(Proteins("UAA").AsEnumerable())
+        Assert.Empty(Proteins("UAA"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_2()
-        Assert.Empty(Proteins("UAG").AsEnumerable())
+        Assert.Empty(Proteins("UAG"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_3()
-        Assert.Empty(Proteins("UGA").AsEnumerable())
+        Assert.Empty(Proteins("UGA"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Sequence_of_two_protein_codons_translates_into_proteins()
-        Assert.Equal({"Phenylalanine", "Phenylalanine"}, Proteins("UUUUUU").AsEnumerable())
+        Dim strand = "UUUUUU"
+        Dim expected = {"Phenylalanine", "Phenylalanine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Sequence_of_two_different_protein_codons_translates_into_proteins()
-        Assert.Equal({"Leucine", "Leucine"}, Proteins("UUAUUG").AsEnumerable())
+        Dim strand = "UUAUUG"
+        Dim expected = {"Leucine", "Leucine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translate_rna_strand_into_correct_protein_list()
-        Assert.Equal({"Methionine", "Phenylalanine", "Tryptophan"}, Proteins("AUGUUUUGG").AsEnumerable())
+        Dim strand = "AUGUUUUGG"
+        Dim expected = {"Methionine", "Phenylalanine", "Tryptophan"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_beginning_of_sequence()
-        Assert.Empty(Proteins("UAGUGG").AsEnumerable())
+        Assert.Empty(Proteins("UAGUGG"))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_end_of_two_codon_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGGUAG").AsEnumerable())
+        Dim strand = "UGGUAG"
+        Dim expected = {"Tryptophan"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_end_of_three_codon_sequence()
-        Assert.Equal({"Methionine", "Phenylalanine"}, Proteins("AUGUUUUAA").AsEnumerable())
+        Dim strand = "AUGUUUUAA"
+        Dim expected = {"Methionine", "Phenylalanine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_in_middle_of_three_codon_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGGUAGUGG").AsEnumerable())
+        Dim strand = "UGGUAGUGG"
+        Dim expected = {"Tryptophan"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_in_middle_of_six_codon_sequence()
-        Assert.Equal({"Tryptophan", "Cysteine", "Tyrosine"}, Proteins("UGGUGUUAUUAAUGGUUU").AsEnumerable())
+        Dim strand = "UGGUGUUAUUAAUGGUUU"
+        Dim expected = {"Tryptophan", "Cysteine", "Tyrosine"}
+        Dim result as IEnumerable(Of String) = Proteins(strand)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/protein-translation/ProteinTranslationTests.vb
+++ b/exercises/practice/protein-translation/ProteinTranslationTests.vb
@@ -8,126 +8,126 @@ Public Class ProteinTranslationTests
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Methionine_rna_sequence()
-        Assert.Equal({"Methionine"}, Proteins("AUG"))
+        Assert.Equal({"Methionine"}, Proteins("AUG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phenylalanine_rna_sequence_1()
-        Assert.Equal({"Phenylalanine"}, Proteins("UUU"))
+        Assert.Equal({"Phenylalanine"}, Proteins("UUU").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phenylalanine_rna_sequence_2()
-        Assert.Equal({"Phenylalanine"}, Proteins("UUC"))
+        Assert.Equal({"Phenylalanine"}, Proteins("UUC").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Leucine_rna_sequence_1()
-        Assert.Equal({"Leucine"}, Proteins("UUA"))
+        Assert.Equal({"Leucine"}, Proteins("UUA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Leucine_rna_sequence_2()
-        Assert.Equal({"Leucine"}, Proteins("UUG"))
+        Assert.Equal({"Leucine"}, Proteins("UUG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_1()
-        Assert.Equal({"Serine"}, Proteins("UCU"))
+        Assert.Equal({"Serine"}, Proteins("UCU").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_2()
-        Assert.Equal({"Serine"}, Proteins("UCC"))
+        Assert.Equal({"Serine"}, Proteins("UCC").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_3()
-        Assert.Equal({"Serine"}, Proteins("UCA"))
+        Assert.Equal({"Serine"}, Proteins("UCA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Serine_rna_sequence_4()
-        Assert.Equal({"Serine"}, Proteins("UCG"))
+        Assert.Equal({"Serine"}, Proteins("UCG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tyrosine_rna_sequence_1()
-        Assert.Equal({"Tyrosine"}, Proteins("UAU"))
+        Assert.Equal({"Tyrosine"}, Proteins("UAU").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tyrosine_rna_sequence_2()
-        Assert.Equal({"Tyrosine"}, Proteins("UAC"))
+        Assert.Equal({"Tyrosine"}, Proteins("UAC").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cysteine_rna_sequence_1()
-        Assert.Equal({"Cysteine"}, Proteins("UGU"))
+        Assert.Equal({"Cysteine"}, Proteins("UGU").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Cysteine_rna_sequence_2()
-        Assert.Equal({"Cysteine"}, Proteins("UGC"))
+        Assert.Equal({"Cysteine"}, Proteins("UGC").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Tryptophan_rna_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGG"))
+        Assert.Equal({"Tryptophan"}, Proteins("UGG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_1()
-        Assert.Empty(Proteins("UAA"))
+        Assert.Empty(Proteins("UAA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_2()
-        Assert.Empty(Proteins("UAG"))
+        Assert.Empty(Proteins("UAG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Stop_codon_rna_sequence_3()
-        Assert.Empty(Proteins("UGA"))
+        Assert.Empty(Proteins("UGA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Sequence_of_two_protein_codons_translates_into_proteins()
-        Assert.Equal({"Phenylalanine", "Phenylalanine"}, Proteins("UUUUUU"))
+        Assert.Equal({"Phenylalanine", "Phenylalanine"}, Proteins("UUUUUU").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Sequence_of_two_different_protein_codons_translates_into_proteins()
-        Assert.Equal({"Leucine", "Leucine"}, Proteins("UUAUUG"))
+        Assert.Equal({"Leucine", "Leucine"}, Proteins("UUAUUG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translate_rna_strand_into_correct_protein_list()
-        Assert.Equal({"Methionine", "Phenylalanine", "Tryptophan"}, Proteins("AUGUUUUGG"))
+        Assert.Equal({"Methionine", "Phenylalanine", "Tryptophan"}, Proteins("AUGUUUUGG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_beginning_of_sequence()
-        Assert.Empty(Proteins("UAGUGG"))
+        Assert.Empty(Proteins("UAGUGG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_end_of_two_codon_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGGUAG"))
+        Assert.Equal({"Tryptophan"}, Proteins("UGGUAG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_at_end_of_three_codon_sequence()
-        Assert.Equal({"Methionine", "Phenylalanine"}, Proteins("AUGUUUUAA"))
+        Assert.Equal({"Methionine", "Phenylalanine"}, Proteins("AUGUUUUAA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_in_middle_of_three_codon_sequence()
-        Assert.Equal({"Tryptophan"}, Proteins("UGGUAGUGG"))
+        Assert.Equal({"Tryptophan"}, Proteins("UGGUAGUGG").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Translation_stops_if_stop_codon_in_middle_of_six_codon_sequence()
-        Assert.Equal({"Tryptophan", "Cysteine", "Tyrosine"}, Proteins("UGGUGUUAUUAAUGGUUU"))
+        Assert.Equal({"Tryptophan", "Cysteine", "Tyrosine"}, Proteins("UGGUGUUAUUAAUGGUUU").AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/proverb/Proverb.vbproj
+++ b/exercises/practice/proverb/Proverb.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/proverb/Proverb.vbproj
+++ b/exercises/practice/proverb/Proverb.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/proverb/ProverbTests.vb
+++ b/exercises/practice/proverb/ProverbTests.vb
@@ -6,41 +6,41 @@ Public Class ProverbTests
     Public Sub Zero_pieces()
         Dim strings = Array.Empty(Of String)()
         Dim expected = Array.Empty(Of String)()
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub One_piece()
         Dim strings = {"nail"}
         Dim expected = {"And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_pieces()
         Dim strings = {"nail", "shoe"}
         Dim expected = {"For want of a nail the shoe was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Three_pieces()
         Dim strings = {"nail", "shoe", "horse"}
         Dim expected = {"For want of a nail the shoe was lost.", "For want of a shoe the horse was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Full_proverb()
         Dim strings = {"nail", "shoe", "horse", "rider", "message", "battle", "kingdom"}
         Dim expected = {"For want of a nail the shoe was lost.", "For want of a shoe the horse was lost.", "For want of a horse the rider was lost.", "For want of a rider the message was lost.", "For want of a message the battle was lost.", "For want of a battle the kingdom was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Four_pieces_modernized()
         Dim strings = {"pin", "gun", "soldier", "battle"}
         Dim expected = {"For want of a pin the gun was lost.", "For want of a gun the soldier was lost.", "For want of a soldier the battle was lost.", "And all for the want of a pin."}
-        Assert.Equal(expected, Recite(strings))
+        Assert.Equal(expected, Recite(strings).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/proverb/ProverbTests.vb
+++ b/exercises/practice/proverb/ProverbTests.vb
@@ -6,41 +6,47 @@ Public Class ProverbTests
     Public Sub Zero_pieces()
         Dim strings = Array.Empty(Of String)()
         Dim expected = Array.Empty(Of String)()
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub One_piece()
         Dim strings = {"nail"}
         Dim expected = {"And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_pieces()
         Dim strings = {"nail", "shoe"}
         Dim expected = {"For want of a nail the shoe was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Three_pieces()
         Dim strings = {"nail", "shoe", "horse"}
         Dim expected = {"For want of a nail the shoe was lost.", "For want of a shoe the horse was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Full_proverb()
         Dim strings = {"nail", "shoe", "horse", "rider", "message", "battle", "kingdom"}
         Dim expected = {"For want of a nail the shoe was lost.", "For want of a shoe the horse was lost.", "For want of a horse the rider was lost.", "For want of a rider the message was lost.", "For want of a message the battle was lost.", "For want of a battle the kingdom was lost.", "And all for the want of a nail."}
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Four_pieces_modernized()
         Dim strings = {"pin", "gun", "soldier", "battle"}
         Dim expected = {"For want of a pin the gun was lost.", "For want of a gun the soldier was lost.", "For want of a soldier the battle was lost.", "And all for the want of a pin."}
-        Assert.Equal(expected, Recite(strings).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Recite(strings)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/pythagorean-triplet/PythagoreanTriplet.vbproj
+++ b/exercises/practice/pythagorean-triplet/PythagoreanTriplet.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/pythagorean-triplet/PythagoreanTriplet.vbproj
+++ b/exercises/practice/pythagorean-triplet/PythagoreanTriplet.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/queen-attack/QueenAttack.vbproj
+++ b/exercises/practice/queen-attack/QueenAttack.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/queen-attack/QueenAttack.vbproj
+++ b/exercises/practice/queen-attack/QueenAttack.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.vbproj
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.vbproj
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/raindrops/Raindrops.vbproj
+++ b/exercises/practice/raindrops/Raindrops.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/raindrops/Raindrops.vbproj
+++ b/exercises/practice/raindrops/Raindrops.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/rectangles/Rectangles.vbproj
+++ b/exercises/practice/rectangles/Rectangles.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/rectangles/Rectangles.vbproj
+++ b/exercises/practice/rectangles/Rectangles.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/resistor-color-duo/ResistorColorDuo.vbproj
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuo.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/resistor-color-duo/ResistorColorDuo.vbproj
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuo.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/resistor-color-trio/ResistorColorTrio.vbproj
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrio.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/resistor-color-trio/ResistorColorTrio.vbproj
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrio.vbproj
@@ -1,18 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Example.vb" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/resistor-color/ResistorColor.vbproj
+++ b/exercises/practice/resistor-color/ResistorColor.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/resistor-color/ResistorColor.vbproj
+++ b/exercises/practice/resistor-color/ResistorColor.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/resistor-color/ResistorColorTests.vb
+++ b/exercises/practice/resistor-color/ResistorColorTests.vb
@@ -17,6 +17,6 @@ Public Class ResistorColorTest
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Colors()
-        Assert.Equal({"black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"}, ResistorColor.Colors())
+        Assert.Equal({"black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"}, ResistorColor.Colors().AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/resistor-color/ResistorColorTests.vb
+++ b/exercises/practice/resistor-color/ResistorColorTests.vb
@@ -16,7 +16,9 @@ Public Class ResistorColorTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Colors()
-        Assert.Equal({"black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"}, ResistorColor.Colors().AsEnumerable())
+    Public Sub AllColors()
+        Dim expected = {"black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"}
+        Dim result as IEnumerable(Of String) = Colors()
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/rest-api/RestApi.vbproj
+++ b/exercises/practice/rest-api/RestApi.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/rest-api/RestApi.vbproj
+++ b/exercises/practice/rest-api/RestApi.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/reverse-string/ReverseString.vbproj
+++ b/exercises/practice/reverse-string/ReverseString.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/reverse-string/ReverseString.vbproj
+++ b/exercises/practice/reverse-string/ReverseString.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/rna-transcription/RnaTranscription.vbproj
+++ b/exercises/practice/rna-transcription/RnaTranscription.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/rna-transcription/RnaTranscription.vbproj
+++ b/exercises/practice/rna-transcription/RnaTranscription.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/robot-name/RobotName.vbproj
+++ b/exercises/practice/robot-name/RobotName.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/robot-name/RobotName.vbproj
+++ b/exercises/practice/robot-name/RobotName.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/robot-simulator/RobotSimulator.vbproj
+++ b/exercises/practice/robot-simulator/RobotSimulator.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/robot-simulator/RobotSimulator.vbproj
+++ b/exercises/practice/robot-simulator/RobotSimulator.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/roman-numerals/RomanNumerals.vbproj
+++ b/exercises/practice/roman-numerals/RomanNumerals.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/roman-numerals/RomanNumerals.vbproj
+++ b/exercises/practice/roman-numerals/RomanNumerals.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/rotational-cipher/RotationalCipher.vbproj
+++ b/exercises/practice/rotational-cipher/RotationalCipher.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/rotational-cipher/RotationalCipher.vbproj
+++ b/exercises/practice/rotational-cipher/RotationalCipher.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.vbproj
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.vbproj
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/saddle-points/SaddlePoints.vbproj
+++ b/exercises/practice/saddle-points/SaddlePoints.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/saddle-points/SaddlePoints.vbproj
+++ b/exercises/practice/saddle-points/SaddlePoints.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/say/Say.vbproj
+++ b/exercises/practice/say/Say.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/say/Say.vbproj
+++ b/exercises/practice/say/Say.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/scale-generator/ScaleGenerator.vbproj
+++ b/exercises/practice/scale-generator/ScaleGenerator.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/scale-generator/ScaleGenerator.vbproj
+++ b/exercises/practice/scale-generator/ScaleGenerator.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/scale-generator/ScaleGeneratorTests.vb
+++ b/exercises/practice/scale-generator/ScaleGeneratorTests.vb
@@ -4,102 +4,119 @@ Public Class ScaleGeneratorTests
     <Fact>
     Public Sub Chromatic_scale_with_sharps()
         Dim expected = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
-        Assert.Equal(expected, Chromatic("C").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Chromatic("C")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Chromatic_scale_with_flats()
         Dim expected = {"F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E"}
-        Assert.Equal(expected, Chromatic("F").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Chromatic("F")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Simple_major_scale()
         Dim expected = {"C", "D", "E", "F", "G", "A", "B", "C"}
-        Assert.Equal(expected, Interval("C", "MMmMMMm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("C", "MMmMMMm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Major_scale_with_sharps()
         Dim expected = {"G", "A", "B", "C", "D", "E", "F#", "G"}
-        Assert.Equal(expected, Interval("G", "MMmMMMm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("G", "MMmMMMm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Major_scale_with_flats()
         Dim expected = {"F", "G", "A", "Bb", "C", "D", "E", "F"}
-        Assert.Equal(expected, Interval("F", "MMmMMMm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("F", "MMmMMMm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minor_scale_with_sharps()
         Dim expected = {"F#", "G#", "A", "B", "C#", "D", "E", "F#"}
-        Assert.Equal(expected, Interval("f#", "MmMMmMM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("f#", "MmMMmMM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minor_scale_with_flats()
         Dim expected = {"Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb"}
-        Assert.Equal(expected, Interval("bb", "MmMMmMM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("bb", "MmMMmMM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Dorian_mode()
         Dim expected = {"D", "E", "F", "G", "A", "B", "C", "D"}
-        Assert.Equal(expected, Interval("d", "MmMMMmM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("d", "MmMMMmM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Mixolydian_mode()
         Dim expected = {"Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb"}
-        Assert.Equal(expected, Interval("Eb", "MMmMMmM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("Eb", "MMmMMmM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Lydian_mode()
         Dim expected = {"A", "B", "C#", "D#", "E", "F#", "G#", "A"}
-        Assert.Equal(expected, Interval("a", "MMMmMMm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("A", "MMMmMMm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phrygian_mode()
         Dim expected = {"E", "F", "G", "A", "B", "C", "D", "E"}
-        Assert.Equal(expected, Interval("e", "mMMMmMM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("e", "mMMMmMM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Locrian_mode()
         Dim expected = {"G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"}
-        Assert.Equal(expected, Interval("g", "mMMmMMM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("g", "mMMmMMM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Harmonic_minor()
         Dim expected = {"D", "E", "F", "G", "A", "Bb", "Db", "D"}
-        Assert.Equal(expected, Interval("d", "MmMMmAm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("d", "MmMMmAm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Octatonic()
         Dim expected = {"C", "D", "D#", "F", "F#", "G#", "A", "B", "C"}
-        Assert.Equal(expected, Interval("C", "MmMmMmMm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("C", "MmMmMmMm")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Hexatonic()
         Dim expected = {"Db", "Eb", "F", "G", "A", "B", "Db"}
-        Assert.Equal(expected, Interval("Db", "MMMMMM").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("Db", "MMMMMM")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Pentatonic()
         Dim expected = {"A", "B", "C#", "E", "F#", "A"}
-        Assert.Equal(expected, Interval("A", "MMAMA").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("A", "MMAMA")
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Enigmatic()
         Dim expected = {"G", "G#", "B", "C#", "D#", "F", "F#", "G"}
-        Assert.Equal(expected, Interval("G", "mAMMMmm").AsEnumerable())
+        Dim result As IEnumerable(Of String) = Interval("G", "mAMMMmm")
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/scale-generator/ScaleGeneratorTests.vb
+++ b/exercises/practice/scale-generator/ScaleGeneratorTests.vb
@@ -4,102 +4,102 @@ Public Class ScaleGeneratorTests
     <Fact>
     Public Sub Chromatic_scale_with_sharps()
         Dim expected = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
-        Assert.Equal(expected, Chromatic("C"))
+        Assert.Equal(expected, Chromatic("C").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Chromatic_scale_with_flats()
         Dim expected = {"F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E"}
-        Assert.Equal(expected, Chromatic("F"))
+        Assert.Equal(expected, Chromatic("F").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Simple_major_scale()
         Dim expected = {"C", "D", "E", "F", "G", "A", "B", "C"}
-        Assert.Equal(expected, Interval("C", "MMmMMMm"))
+        Assert.Equal(expected, Interval("C", "MMmMMMm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Major_scale_with_sharps()
         Dim expected = {"G", "A", "B", "C", "D", "E", "F#", "G"}
-        Assert.Equal(expected, Interval("G", "MMmMMMm"))
+        Assert.Equal(expected, Interval("G", "MMmMMMm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Major_scale_with_flats()
         Dim expected = {"F", "G", "A", "Bb", "C", "D", "E", "F"}
-        Assert.Equal(expected, Interval("F", "MMmMMMm"))
+        Assert.Equal(expected, Interval("F", "MMmMMMm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minor_scale_with_sharps()
         Dim expected = {"F#", "G#", "A", "B", "C#", "D", "E", "F#"}
-        Assert.Equal(expected, Interval("f#", "MmMMmMM"))
+        Assert.Equal(expected, Interval("f#", "MmMMmMM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Minor_scale_with_flats()
         Dim expected = {"Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb"}
-        Assert.Equal(expected, Interval("bb", "MmMMmMM"))
+        Assert.Equal(expected, Interval("bb", "MmMMmMM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Dorian_mode()
         Dim expected = {"D", "E", "F", "G", "A", "B", "C", "D"}
-        Assert.Equal(expected, Interval("d", "MmMMMmM"))
+        Assert.Equal(expected, Interval("d", "MmMMMmM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Mixolydian_mode()
         Dim expected = {"Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb"}
-        Assert.Equal(expected, Interval("Eb", "MMmMMmM"))
+        Assert.Equal(expected, Interval("Eb", "MMmMMmM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Lydian_mode()
         Dim expected = {"A", "B", "C#", "D#", "E", "F#", "G#", "A"}
-        Assert.Equal(expected, Interval("a", "MMMmMMm"))
+        Assert.Equal(expected, Interval("a", "MMMmMMm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Phrygian_mode()
         Dim expected = {"E", "F", "G", "A", "B", "C", "D", "E"}
-        Assert.Equal(expected, Interval("e", "mMMMmMM"))
+        Assert.Equal(expected, Interval("e", "mMMMmMM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Locrian_mode()
         Dim expected = {"G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"}
-        Assert.Equal(expected, Interval("g", "mMMmMMM"))
+        Assert.Equal(expected, Interval("g", "mMMmMMM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Harmonic_minor()
         Dim expected = {"D", "E", "F", "G", "A", "Bb", "Db", "D"}
-        Assert.Equal(expected, Interval("d", "MmMMmAm"))
+        Assert.Equal(expected, Interval("d", "MmMMmAm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Octatonic()
         Dim expected = {"C", "D", "D#", "F", "F#", "G#", "A", "B", "C"}
-        Assert.Equal(expected, Interval("C", "MmMmMmMm"))
+        Assert.Equal(expected, Interval("C", "MmMmMmMm").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Hexatonic()
         Dim expected = {"Db", "Eb", "F", "G", "A", "B", "Db"}
-        Assert.Equal(expected, Interval("Db", "MMMMMM"))
+        Assert.Equal(expected, Interval("Db", "MMMMMM").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Pentatonic()
         Dim expected = {"A", "B", "C#", "E", "F#", "A"}
-        Assert.Equal(expected, Interval("A", "MMAMA"))
+        Assert.Equal(expected, Interval("A", "MMAMA").AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Enigmatic()
         Dim expected = {"G", "G#", "B", "C#", "D#", "F", "F#", "G"}
-        Assert.Equal(expected, Interval("G", "mAMMMmm"))
+        Assert.Equal(expected, Interval("G", "mAMMMmm").AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/scrabble-score/ScrabbleScore.vbproj
+++ b/exercises/practice/scrabble-score/ScrabbleScore.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/scrabble-score/ScrabbleScore.vbproj
+++ b/exercises/practice/scrabble-score/ScrabbleScore.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/secret-handshake/SecretHandshake.vbproj
+++ b/exercises/practice/secret-handshake/SecretHandshake.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/secret-handshake/SecretHandshake.vbproj
+++ b/exercises/practice/secret-handshake/SecretHandshake.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/secret-handshake/SecretHandshakeTests.vb
+++ b/exercises/practice/secret-handshake/SecretHandshakeTests.vb
@@ -3,56 +3,74 @@ Imports Xunit
 Public Class SecretHandshakeTests
     <Fact>
     Public Sub Wink_for_1()
-        Assert.Equal({"wink"}, SecretHandshake.Commands(1).AsEnumerable())
+        Dim expected = {"wink"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(1)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Double_blink_for_10()
-        Assert.Equal({"double blink"}, SecretHandshake.Commands(2).AsEnumerable())
+        Dim expected = {"double blink"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(2) 
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Close_your_eyes_for_100()
-        Assert.Equal({"close your eyes"}, SecretHandshake.Commands(4).AsEnumerable())
+        Dim expected = {"close your eyes"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(4)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Jump_for_1000()
-        Assert.Equal({"jump"}, SecretHandshake.Commands(8).AsEnumerable())
+        Dim expected = {"jump"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(8)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Combine_two_actions()
-        Assert.Equal({"wink", "double blink"}, SecretHandshake.Commands(3).AsEnumerable())
+        Dim expected = {"wink", "double blink"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(3)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reverse_two_actions()
-        Assert.Equal({"double blink", "wink"}, SecretHandshake.Commands(19).AsEnumerable())
+        Dim expected = {"double blink", "wink"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(19)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reversing_one_action_gives_the_same_action()
-        Assert.Equal({"jump"}, SecretHandshake.Commands(24).AsEnumerable())
+        Dim expected = {"jump"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(24)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reversing_no_actions_still_gives_no_actions()
-        Assert.Empty(SecretHandshake.Commands(16).AsEnumerable())
+        Assert.Empty(SecretHandshake.Commands(16))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub All_possible_actions()
-        Assert.Equal({"wink", "double blink", "close your eyes", "jump"}, SecretHandshake.Commands(15).AsEnumerable())
+        Dim expected = {"wink", "double blink", "close your eyes", "jump"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(15)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reverse_all_possible_actions()
-        Assert.Equal({"jump", "close your eyes", "double blink", "wink"}, SecretHandshake.Commands(31).AsEnumerable())
+        Dim expected = {"jump", "close your eyes", "double blink", "wink"}
+        Dim result As IEnumerable(Of String) = SecretHandshake.Commands(31)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Do_nothing_for_zero()
-        Assert.Empty(SecretHandshake.Commands(0).AsEnumerable())
+        Assert.Empty(SecretHandshake.Commands(0))
     End Sub
 End Class

--- a/exercises/practice/secret-handshake/SecretHandshakeTests.vb
+++ b/exercises/practice/secret-handshake/SecretHandshakeTests.vb
@@ -3,56 +3,56 @@ Imports Xunit
 Public Class SecretHandshakeTests
     <Fact>
     Public Sub Wink_for_1()
-        Assert.Equal({"wink"}, SecretHandshake.Commands(1))
+        Assert.Equal({"wink"}, SecretHandshake.Commands(1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Double_blink_for_10()
-        Assert.Equal({"double blink"}, SecretHandshake.Commands(2))
+        Assert.Equal({"double blink"}, SecretHandshake.Commands(2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Close_your_eyes_for_100()
-        Assert.Equal({"close your eyes"}, SecretHandshake.Commands(4))
+        Assert.Equal({"close your eyes"}, SecretHandshake.Commands(4).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Jump_for_1000()
-        Assert.Equal({"jump"}, SecretHandshake.Commands(8))
+        Assert.Equal({"jump"}, SecretHandshake.Commands(8).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Combine_two_actions()
-        Assert.Equal({"wink", "double blink"}, SecretHandshake.Commands(3))
+        Assert.Equal({"wink", "double blink"}, SecretHandshake.Commands(3).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reverse_two_actions()
-        Assert.Equal({"double blink", "wink"}, SecretHandshake.Commands(19))
+        Assert.Equal({"double blink", "wink"}, SecretHandshake.Commands(19).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reversing_one_action_gives_the_same_action()
-        Assert.Equal({"jump"}, SecretHandshake.Commands(24))
+        Assert.Equal({"jump"}, SecretHandshake.Commands(24).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reversing_no_actions_still_gives_no_actions()
-        Assert.Empty(SecretHandshake.Commands(16))
+        Assert.Empty(SecretHandshake.Commands(16).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub All_possible_actions()
-        Assert.Equal({"wink", "double blink", "close your eyes", "jump"}, SecretHandshake.Commands(15))
+        Assert.Equal({"wink", "double blink", "close your eyes", "jump"}, SecretHandshake.Commands(15).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Reverse_all_possible_actions()
-        Assert.Equal({"jump", "close your eyes", "double blink", "wink"}, SecretHandshake.Commands(31))
+        Assert.Equal({"jump", "close your eyes", "double blink", "wink"}, SecretHandshake.Commands(31).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Do_nothing_for_zero()
-        Assert.Empty(SecretHandshake.Commands(0))
+        Assert.Empty(SecretHandshake.Commands(0).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/series/Series.vbproj
+++ b/exercises/practice/series/Series.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/series/Series.vbproj
+++ b/exercises/practice/series/Series.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/series/SeriesTests.vb
+++ b/exercises/practice/series/SeriesTests.vb
@@ -6,61 +6,61 @@ Public Class SeriesTests
     <Fact>
     Public Sub Slices_of_one_from_one()
         Dim expected = {"1"}
-        Assert.Equal(expected, Slices("1", 1).ToArray())
+        Assert.Equal(expected, Slices("1", 1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_one_from_two()
         Dim expected = {"1", "2"}
-        Assert.Equal(expected, Slices("12", 1).ToArray())
+        Assert.Equal(expected, Slices("12", 1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_two()
         Dim expected = {"35"}
-        Assert.Equal(expected, Slices("35", 2).ToArray())
+        Assert.Equal(expected, Slices("35", 2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_two_overlap()
         Dim expected = {"91", "14", "42"}
-        Assert.Equal(expected, Slices("9142", 2).ToArray())
+        Assert.Equal(expected, Slices("9142", 2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_can_include_duplicates()
         Dim expected = {"777", "777", "777", "777"}
-        Assert.Equal(expected, Slices("777777", 3).ToArray())
+        Assert.Equal(expected, Slices("777777", 3).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_a_long_series()
         Dim expected = {"91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243"}
-        Assert.Equal(expected, Slices("918493904243", 5).ToArray())
+        Assert.Equal(expected, Slices("918493904243", 5).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_is_too_large()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 6).ToArray())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 6).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_is_way_too_large()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 42).ToArray())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 42).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_cannot_be_zero()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 0).ToArray())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 0).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_cannot_be_negative()
-        Assert.Throws(Of ArgumentException)(Function() Slices("123", -1).ToArray())
+        Assert.Throws(Of ArgumentException)(Function() Slices("123", -1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Empty_series_is_invalid()
-        Assert.Throws(Of ArgumentException)(Function() Slices("", 1).ToArray())
+        Assert.Throws(Of ArgumentException)(Function() Slices("", 1).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/series/SeriesTests.vb
+++ b/exercises/practice/series/SeriesTests.vb
@@ -6,61 +6,67 @@ Public Class SeriesTests
     <Fact>
     Public Sub Slices_of_one_from_one()
         Dim expected = {"1"}
-        Assert.Equal(expected, Slices("1", 1).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Slices("1", 1)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_one_from_two()
         Dim expected = {"1", "2"}
-        Assert.Equal(expected, Slices("12", 1).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Slices("12", 1)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_two()
         Dim expected = {"35"}
-        Assert.Equal(expected, Slices("35", 2).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Slices("35", 2)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_two_overlap()
         Dim expected = {"91", "14", "42"}
-        Assert.Equal(expected, Slices("9142", 2).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Slices("9142", 2)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_can_include_duplicates()
         Dim expected = {"777", "777", "777", "777"}
-        Assert.Equal(expected, Slices("777777", 3).AsEnumerable())
+        Dim result As IEnumerable(Of String) = Slices("777777", 3)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slices_of_a_long_series()
         Dim expected = {"91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243"}
-        Assert.Equal(expected, Slices("918493904243", 5).AsEnumerable())
+        Dim result as IEnumerable(Of String) = Slices("918493904243", 5)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_is_too_large()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 6).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 6))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_is_way_too_large()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 42).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 42))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_cannot_be_zero()
-        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 0).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Slices("12345", 0))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Slice_length_cannot_be_negative()
-        Assert.Throws(Of ArgumentException)(Function() Slices("123", -1).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Slices("123", -1))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Empty_series_is_invalid()
-        Assert.Throws(Of ArgumentException)(Function() Slices("", 1).AsEnumerable())
+        Assert.Throws(Of ArgumentException)(Function() Slices("", 1))
     End Sub
 End Class

--- a/exercises/practice/sieve/Sieve.vbproj
+++ b/exercises/practice/sieve/Sieve.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/sieve/Sieve.vbproj
+++ b/exercises/practice/sieve/Sieve.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/sieve/SieveTests.vb
+++ b/exercises/practice/sieve/SieveTests.vb
@@ -4,31 +4,39 @@ Imports Xunit
 Public Class SieveTests
     <Fact>
     Public Sub No_primes_under_two()
-        Assert.Empty(Sieve.Primes(1).AsEnumerable())
+        Assert.Empty(Sieve.Primes(1))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_first_prime()
-        Assert.Equal({2}, Sieve.Primes(2).AsEnumerable())
+        Dim expected = {2}
+        Dim result As IEnumerable(Of Integer) = Sieve.Primes(2)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_primes_up_to_10()
-        Assert.Equal({2, 3, 5, 7}, Sieve.Primes(10).AsEnumerable())
+        Dim expected = {2, 3, 5, 7}
+        Dim result As IEnumerable(Of Integer) = Sieve.Primes(10)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Limit_is_prime()
-        Assert.Equal({2, 3, 5, 7, 11, 13}, Sieve.Primes(13).AsEnumerable())
+        Dim expected = {2, 3, 5, 7, 11}
+        Dim result As IEnumerable(Of Integer) = Sieve.Primes(11)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_primes_up_to_1000()
-        Assert.Equal({2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997}, Sieve.Primes(1000).AsEnumerable())
+        Dim expected = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997}
+        Dim result As IEnumerable(Of Integer) = Sieve.Primes(1000)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_negative_numbers()
-        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Sieve.Primes(-1).AsEnumerable())
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Sieve.Primes(-1))
     End Sub
 End Class

--- a/exercises/practice/sieve/SieveTests.vb
+++ b/exercises/practice/sieve/SieveTests.vb
@@ -4,31 +4,31 @@ Imports Xunit
 Public Class SieveTests
     <Fact>
     Public Sub No_primes_under_two()
-        Assert.Empty(Sieve.Primes(1).ToArray())
+        Assert.Empty(Sieve.Primes(1).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_first_prime()
-        Assert.Equal({2}, Sieve.Primes(2).ToArray())
+        Assert.Equal({2}, Sieve.Primes(2).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_primes_up_to_10()
-        Assert.Equal({2, 3, 5, 7}, Sieve.Primes(10).ToArray())
+        Assert.Equal({2, 3, 5, 7}, Sieve.Primes(10).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Limit_is_prime()
-        Assert.Equal({2, 3, 5, 7, 11, 13}, Sieve.Primes(13).ToArray())
+        Assert.Equal({2, 3, 5, 7, 11, 13}, Sieve.Primes(13).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Find_primes_up_to_1000()
-        Assert.Equal({2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997}, Sieve.Primes(1000).ToArray())
+        Assert.Equal({2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997}, Sieve.Primes(1000).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub No_negative_numbers()
-        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Sieve.Primes(-1).ToArray())
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Sieve.Primes(-1).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/simple-cipher/SimpleCipher.vbproj
+++ b/exercises/practice/simple-cipher/SimpleCipher.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/simple-cipher/SimpleCipher.vbproj
+++ b/exercises/practice/simple-cipher/SimpleCipher.vbproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <OptionInfer>On</OptionInfer>
-    <TargetFramework>net7.0</TargetFramework>
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.cs</DefaultItemExcludes>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.vbproj
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.vbproj
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.vbproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <OptionInfer>On</OptionInfer>
-    <TargetFramework>net7.0</TargetFramework>
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.cs</DefaultItemExcludes>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/space-age/SpaceAge.vbproj
+++ b/exercises/practice/space-age/SpaceAge.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/space-age/SpaceAge.vbproj
+++ b/exercises/practice/space-age/SpaceAge.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/spiral-matrix/SpiralMatrix.vbproj
+++ b/exercises/practice/spiral-matrix/SpiralMatrix.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/spiral-matrix/SpiralMatrix.vbproj
+++ b/exercises/practice/spiral-matrix/SpiralMatrix.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/sublist/Sublist.vbproj
+++ b/exercises/practice/sublist/Sublist.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/sublist/Sublist.vbproj
+++ b/exercises/practice/sublist/Sublist.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.vbproj
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.vbproj
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/tournament/Tournament.vbproj
+++ b/exercises/practice/tournament/Tournament.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/tournament/Tournament.vbproj
+++ b/exercises/practice/tournament/Tournament.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/transpose/Transpose.vbproj
+++ b/exercises/practice/transpose/Transpose.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/transpose/Transpose.vbproj
+++ b/exercises/practice/transpose/Transpose.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/tree-building/TreeBuilding.vbproj
+++ b/exercises/practice/tree-building/TreeBuilding.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/tree-building/TreeBuilding.vbproj
+++ b/exercises/practice/tree-building/TreeBuilding.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/triangle/Triangle.vbproj
+++ b/exercises/practice/triangle/Triangle.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/triangle/Triangle.vbproj
+++ b/exercises/practice/triangle/Triangle.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/twelve-days/TwelveDays.vbproj
+++ b/exercises/practice/twelve-days/TwelveDays.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/twelve-days/TwelveDays.vbproj
+++ b/exercises/practice/twelve-days/TwelveDays.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/two-bucket/TwoBucket.vbproj
+++ b/exercises/practice/two-bucket/TwoBucket.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/two-bucket/TwoBucket.vbproj
+++ b/exercises/practice/two-bucket/TwoBucket.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/two-fer/TwoFer.vbproj
+++ b/exercises/practice/two-fer/TwoFer.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/two-fer/TwoFer.vbproj
+++ b/exercises/practice/two-fer/TwoFer.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/two-fer/TwoFerTests.vb
+++ b/exercises/practice/two-fer/TwoFerTests.vb
@@ -18,6 +18,6 @@ Public Class TwoFerTests
     Public Sub AnotherNameGiven()
         Dim expected = "One for Bob, one for me."
         Dim result as String = TwoFer.Speak("Bob")
-        Asset.Equal(expected, result)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/two-fer/TwoFerTests.vb
+++ b/exercises/practice/two-fer/TwoFerTests.vb
@@ -2,16 +2,22 @@ Imports Xunit
 Public Class TwoFerTests
     <Fact>
     Public Sub NoNameGiven()
-        Assert.Equal("One for you, one for me.", TwoFer.Speak(), false)
+        Dim expected = "One for you, one for me."
+        Dim result as String = TwoFer.Speak()
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ANameGiven()
-        Assert.Equal("One for Alice, one for me.", TwoFer.Speak("Alice"), false)
+        Dim expected = "One for Alice, one for me."
+        Dim result as String = TwoFer.Speak("Alice")
+        Assert.Equal(expected, result)
     End Sub
   
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AnotherNameGiven()
-        Assert.Equal("One for Bob, one for me.", TwoFer.Speak("Bob"), false)
+        Dim expected = "One for Bob, one for me."
+        Dim result as String = TwoFer.Speak("Bob")
+        Asset.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/two-fer/TwoFerTests.vb
+++ b/exercises/practice/two-fer/TwoFerTests.vb
@@ -2,16 +2,16 @@ Imports Xunit
 Public Class TwoFerTests
     <Fact>
     Public Sub NoNameGiven()
-        Assert.Equal("One for you, one for me.", TwoFer.Speak())
+        Assert.Equal("One for you, one for me.", TwoFer.Speak(), false)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub ANameGiven()
-        Assert.Equal("One for Alice, one for me.", TwoFer.Speak("Alice"))
+        Assert.Equal("One for Alice, one for me.", TwoFer.Speak("Alice"), false)
     End Sub
   
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub AnotherNameGiven()
-        Assert.Equal("One for Bob, one for me.", TwoFer.Speak("Bob"))
+        Assert.Equal("One for Bob, one for me.", TwoFer.Speak("Bob"), false)
     End Sub
 End Class

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.vbproj
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.vbproj
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
@@ -6,179 +6,179 @@ Public Class VariableLengthQuantityTests
     Public Sub Zero()
         Dim integers = {&H0UI}
         Dim expected = {&H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_single_byte()
         Dim integers = {&H40UI}
         Dim expected = {&H40UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_single_byte()
         Dim integers = {&H7FUI}
         Dim expected = {&H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_double_byte()
         Dim integers = {&H80UI}
         Dim expected = {&H81UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_double_byte()
         Dim integers = {&H2000UI}
         Dim expected = {&HC0UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_double_byte()
         Dim integers = {&H3FFFUI}
         Dim expected = {&HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_triple_byte()
         Dim integers = {&H4000UI}
         Dim expected = {&H81UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_triple_byte()
         Dim integers = {&H100000UI}
         Dim expected = {&HC0UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_triple_byte()
         Dim integers = {&H1FFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_quadruple_byte()
         Dim integers = {&H200000UI}
         Dim expected = {&H81UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_quadruple_byte()
         Dim integers = {&H8000000UI}
         Dim expected = {&HC0UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_quadruple_byte()
         Dim integers = {&HFFFFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_quintuple_byte()
         Dim integers = {&H10000000UI}
         Dim expected = {&H81UI, &H80UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_quintuple_byte()
         Dim integers = {&HFF000000UI}
         Dim expected = {&H8FUI, &HF8UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Maximum_32_bit_integer_input()
         Dim integers = {&HFFFFFFFFUI}
         Dim expected = {&H8FUI, &HFFUI, &HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_single_byte_values()
         Dim integers = {&H40UI, &H7FUI}
         Dim expected = {&H40UI, &H7FUI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_multi_byte_values()
         Dim integers = {&H4000UI, &H123456UI}
         Dim expected = {&H81UI, &H80UI, &H0UI, &HC8UI, &HE8UI, &H56UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Many_multi_byte_values()
         Dim integers = {&H2000UI, &H123456UI, &HFFFFFFFUI, &H0UI, &H3FFFUI, &H4000UI}
         Dim expected = {&HC0UI, &H0UI, &HC8UI, &HE8UI, &H56UI, &HFFUI, &HFFUI, &HFFUI, &H7FUI, &H0UI, &HFFUI, &H7FUI, &H81UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers))
+        Assert.Equal(expected, Encode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub One_byte()
         Dim integers = {&H7FUI}
         Dim expected = {&H7FUI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_bytes()
         Dim integers = {&HC0UI, &H0UI}
         Dim expected = {&H2000UI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Three_bytes()
         Dim integers = {&HFFUI, &HFFUI, &H7FUI}
         Dim expected = {&H1FFFFFUI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Four_bytes()
         Dim integers = {&H81UI, &H80UI, &H80UI, &H0UI}
         Dim expected = {&H200000UI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Maximum_32_bit_integer()
         Dim integers = {&H8FUI, &HFFUI, &HFFUI, &HFFUI, &H7FUI}
         Dim expected = {&HFFFFFFFFUI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Incomplete_sequence_causes_error()
         Dim integers = {&HFFUI}
-        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers))
+        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Incomplete_sequence_causes_error_even_if_value_is_zero()
         Dim integers = {&H80UI}
-        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers))
+        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers).AsEnumerable())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Multiple_values()
         Dim integers = {&HC0UI, &H0UI, &HC8UI, &HE8UI, &H56UI, &HFFUI, &HFFUI, &HFFUI, &H7FUI, &H0UI, &HFFUI, &H7FUI, &H81UI, &H80UI, &H0UI}
         Dim expected = {&H2000UI, &H123456UI, &HFFFFFFFUI, &H0UI, &H3FFFUI, &H4000UI}
-        Assert.Equal(expected, Decode(integers))
+        Assert.Equal(expected, Decode(integers).AsEnumerable())
     End Sub
 End Class

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
@@ -6,179 +6,203 @@ Public Class VariableLengthQuantityTests
     Public Sub Zero()
         Dim integers = {&H0UI}
         Dim expected = {&H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_single_byte()
         Dim integers = {&H40UI}
         Dim expected = {&H40UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_single_byte()
         Dim integers = {&H7FUI}
         Dim expected = {&H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_double_byte()
         Dim integers = {&H80UI}
         Dim expected = {&H81UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_double_byte()
         Dim integers = {&H2000UI}
         Dim expected = {&HC0UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_double_byte()
         Dim integers = {&H3FFFUI}
         Dim expected = {&HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_triple_byte()
         Dim integers = {&H4000UI}
         Dim expected = {&H81UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_triple_byte()
         Dim integers = {&H100000UI}
         Dim expected = {&HC0UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_triple_byte()
         Dim integers = {&H1FFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_quadruple_byte()
         Dim integers = {&H200000UI}
         Dim expected = {&H81UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_quadruple_byte()
         Dim integers = {&H8000000UI}
         Dim expected = {&HC0UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_quadruple_byte()
         Dim integers = {&HFFFFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Smallest_quintuple_byte()
         Dim integers = {&H10000000UI}
         Dim expected = {&H81UI, &H80UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Arbitrary_quintuple_byte()
         Dim integers = {&HFF000000UI}
         Dim expected = {&H8FUI, &HF8UI, &H80UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Maximum_32_bit_integer_input()
         Dim integers = {&HFFFFFFFFUI}
         Dim expected = {&H8FUI, &HFFUI, &HFFUI, &HFFUI, &H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_single_byte_values()
         Dim integers = {&H40UI, &H7FUI}
         Dim expected = {&H40UI, &H7FUI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_multi_byte_values()
         Dim integers = {&H4000UI, &H123456UI}
         Dim expected = {&H81UI, &H80UI, &H0UI, &HC8UI, &HE8UI, &H56UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Many_multi_byte_values()
         Dim integers = {&H2000UI, &H123456UI, &HFFFFFFFUI, &H0UI, &H3FFFUI, &H4000UI}
         Dim expected = {&HC0UI, &H0UI, &HC8UI, &HE8UI, &H56UI, &HFFUI, &HFFUI, &HFFUI, &H7FUI, &H0UI, &HFFUI, &H7FUI, &H81UI, &H80UI, &H0UI}
-        Assert.Equal(expected, Encode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub One_byte()
         Dim integers = {&H7FUI}
         Dim expected = {&H7FUI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Two_bytes()
         Dim integers = {&HC0UI, &H0UI}
         Dim expected = {&H2000UI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Three_bytes()
         Dim integers = {&HFFUI, &HFFUI, &H7FUI}
         Dim expected = {&H1FFFFFUI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Four_bytes()
         Dim integers = {&H81UI, &H80UI, &H80UI, &H0UI}
         Dim expected = {&H200000UI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Maximum_32_bit_integer()
         Dim integers = {&H8FUI, &HFFUI, &HFFUI, &HFFUI, &H7FUI}
         Dim expected = {&HFFFFFFFFUI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Incomplete_sequence_causes_error()
         Dim integers = {&HFFUI}
-        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers).AsEnumerable())
+        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Incomplete_sequence_causes_error_even_if_value_is_zero()
         Dim integers = {&H80UI}
-        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers).AsEnumerable())
+        Assert.Throws(Of InvalidOperationException)(Function() Decode(integers))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Multiple_values()
         Dim integers = {&HC0UI, &H0UI, &HC8UI, &HE8UI, &H56UI, &HFFUI, &HFFUI, &HFFUI, &H7FUI, &H0UI, &HFFUI, &H7FUI, &H81UI, &H80UI, &H0UI}
         Dim expected = {&H2000UI, &H123456UI, &HFFFFFFFUI, &H0UI, &H3FFFUI, &H4000UI}
-        Assert.Equal(expected, Decode(integers).AsEnumerable())
+        Dim result as IEnumerable(Of UInteger) = Decode(integers)
+        Assert.Equal(expected, result)
     End Sub
 End Class

--- a/exercises/practice/word-count/WordCount.vbproj
+++ b/exercises/practice/word-count/WordCount.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/word-count/WordCount.vbproj
+++ b/exercises/practice/word-count/WordCount.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/wordy/Wordy.vbproj
+++ b/exercises/practice/wordy/Wordy.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/wordy/Wordy.vbproj
+++ b/exercises/practice/wordy/Wordy.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/yacht/Yacht.vbproj
+++ b/exercises/practice/yacht/Yacht.vbproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/exercises/practice/yacht/Yacht.vbproj
+++ b/exercises/practice/yacht/Yacht.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/zebra-puzzle/ZebraPuzzle.vbproj
+++ b/exercises/practice/zebra-puzzle/ZebraPuzzle.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/zebra-puzzle/ZebraPuzzle.vbproj
+++ b/exercises/practice/zebra-puzzle/ZebraPuzzle.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>

--- a/exercises/practice/zipper/Zipper.vbproj
+++ b/exercises/practice/zipper/Zipper.vbproj
@@ -7,10 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/exercises/practice/zipper/Zipper.vbproj
+++ b/exercises/practice/zipper/Zipper.vbproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
See https://github.com/exercism/vbnet-test-runner/pull/49 and https://forum.exercism.org/t/upgrade-to-net-9/15843/2. This should be merged in tandem with the test runner PR.

The first commit standardizes vbprojs and bumps the package versions to match what the test runner will use.

The second commit resolves an XUnit bug where arrays can't be directly compared with Assert.Equal for VB.

The third commit flips the expected and actual argument order for Bob.

The fourth commit resolves an ambiguous match exception for comparing two strings. That only affects Bob and Two-Fer for some reason, but I needed to chose a more specific overload. I chose the one that takes a Boolean to set whether case should be ignored.

