### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams must be returned in alphabetical order.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# Hints
+# Instructions append
 
-This exercise requires you to handle data related to currency and money. A normal approuch is to use the [Decimal](https://docs.microsoft.com/en-us/dotnet/api/system.decimal
+## Hints
+
+This exercise requires you to handle data related to currency and money.
+A normal approuch is to use the [Decimal](https://docs.microsoft.com/en-us/dotnet/api/system.decimal).
 Note though that you then only store the numeric value of a currency.

--- a/exercises/practice/beer-song/.docs/instructions.append.md
+++ b/exercises/practice/beer-song/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/difference-of-squares/.docs/instructions.append.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.append.md
@@ -1,4 +1,9 @@
-# Hints
+# Instructions append
 
-This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).
+## Hints
+
+This exercise requires you to process a collection of data.
+You can simplify your code by using LINQ (Language Integrated Query).
+For more information, see [using linq].
+
+[using linq]: https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq

--- a/exercises/practice/diffie-hellman/.docs/instructions.append.md
+++ b/exercises/practice/diffie-hellman/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
 
-This exercise requires you to perform calculations on large numbers. To correctly represent large numbers, the
-[BigInteger](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger
+## Hints
+
+This exercise requires you to perform calculations on large numbers.
+To correctly represent large numbers, the [BigInteger].
+
+[BigInteger]: https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger

--- a/exercises/practice/food-chain/.docs/instructions.append.md
+++ b/exercises/practice/food-chain/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/house/.docs/instructions.append.md
+++ b/exercises/practice/house/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,3 +1,8 @@
-# Hints
+# Instructions append
 
-The `Foldl` and `Foldr` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one. If you'd like more background information, check out this [fold](<https://en.wikipedia.org/wiki/Fold_(higher-order_function)>) page.
+## Hints
+
+The `Foldl` and `Foldr` methods are "fold" functions, which is a concept well-known in the functional programming world, but less so in the object-oriented one.
+If you'd like more background information, check out this [fold] page.
+
+[fold]: https://en.wikipedia.org/wiki/Fold_(higher-order_function)

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
 
-This exercise requires the use of a Dictionary. For more information see
-[this page.](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2
+## Hints
+
+This exercise requires the use of a Dictionary.
+For more information see [idictionary].
+
+[idictionary]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2

--- a/exercises/practice/proverb/.docs/instructions.append.md
+++ b/exercises/practice/proverb/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,3 +1,8 @@
-# Hints
+# Instructions append
 
-This exercise requires you to write an extension method. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods).
+## Hints
+
+This exercise requires you to write an extension method.
+For more information, see [extension methods].
+
+[extension methods]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods

--- a/exercises/practice/saddle-points/.docs/instructions.append.md
+++ b/exercises/practice/saddle-points/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
+
+## Hints
 
 For this exercise, you will need to create a set of factors using tuples.
-For more information on tuples, see [this link](https://docs.microsoft.com/en-us/dotnet/api/system.tuple).
+For more information on tuples, see [tuples].
+
+[tuples]: https://docs.microsoft.com/en-us/dotnet/api/system.tuple

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,10 +1,14 @@
 # Instruction append
 
+## Implementation
+
 This exercise requires you to create a linked list data structure which can be iterated. 
 
 1. Implement the `Count` property - it should not be possible to change its value from the outside
 2. Implement the `Push(T value)` method that adds a value to the list at its head. 
 3. Implement the `Pop()` method which removes and returns a value from the head. 
 4. Add a constructor to allow initialisation with a single value, or with an interable
-5. Implement the `IEnumerable<T>` interface. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1).
+5. Implement the `IEnumerable<T>` interface. For more information, see [ienumerable].
 6. Ensure `Reverse()` method is available. 
+
+[ienumerable]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To be able to compare data, the IComparable interface is used.
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/api/system.icomparable
+For more information, see [icomparable].
+
+[icomparable]: https://docs.microsoft.com/en-us/dotnet/api/system.icomparable

--- a/exercises/practice/sum-of-multiples/.docs/instructions.append.md
+++ b/exercises/practice/sum-of-multiples/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using LINQ (Language Integrated Query).
-For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq).
+For more information, see [using linq].
+
+[using linq]: https://docs.microsoft.com/en-us/dotnet/articles/standard/using-linq

--- a/exercises/practice/twelve-days/.docs/instructions.append.md
+++ b/exercises/practice/twelve-days/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 - Try to capture the structure of the song in your code, where you build up the song by composing its parts.

--- a/exercises/practice/variable-length-quantity/.docs/instructions.append.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.append.md
@@ -1,3 +1,8 @@
-# Hints
+# Instructions append
 
-This exercise requires you to use bitwise operations. For more information, see [this page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators).
+## Hints
+
+This exercise requires you to use bitwise operations.
+For more information, see [bitwise operators].
+
+[bitwise operators]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,8 @@
-# Hints
+# Instructions append
 
-- To parse the text, you could try to use the [Sprache](https://github.com/sprache/Sprache/blob/develop/README.md) library. You can also find a good tutorial [here](https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/).
+## Hints
+
+- To parse the text, you could try to use the [Sprache] library. You can also find a good tutorial [here][tutorial].
+
+[Sprache]: https://github.com/sprache/Sprache/blob/develop/README.md
+[tutorial]: https://www.thomaslevesque.com/2017/02/23/easy-text-parsing-in-c-with-sprache/

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -1,4 +1,8 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This exercise requires you to process a collection of data. You can simplify your code by using lazy sequences to improve performance.
-For more information, see [this page](https://xosfaere.wordpress.com/2010/03/21/lazy-evaluation-in-csharp/).
+For more information, see [lazy evaluation].
+
+[lazy evaluation]: https://xosfaere.wordpress.com/2010/03/21/lazy-evaluation-in-csharp/

--- a/exercises/practice/zipper/.docs/instructions.append.md
+++ b/exercises/practice/zipper/.docs/instructions.append.md
@@ -1,3 +1,8 @@
-# Hints
+# Instructions append
 
-This exercise deals with custom equality. For more information see [this page.](http://www.java2s.com/Tutorial/VB/0120__Class-Module/OverridingtheEqualsMethod.htm)
+## Hints
+
+This exercise deals with custom equality.
+For more information see [overriding].
+
+[overriding]: http://www.java2s.com/Tutorial/VB/0120__Class-Module/OverridingtheEqualsMethod.htm


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.