### PR TITLE
Standardize exercise difficulties

### DIFF
--- a/.github/workflows/sorted.yml
+++ b/.github/workflows/sorted.yml
@@ -13,4 +13,4 @@ jobs:
     name: Check
     uses: exercism/github-actions/.github/workflows/sorted.yml@main
     with:
-      ordering: ".difficulty, .lowercase_name"
+      ordering: ".bucket, .lowercase_name"

--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
         "uuid": "0488d664-0386-4471-b569-01f847ec6054",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "bitwise_operations",
           "filtering"
@@ -55,7 +55,7 @@
         "uuid": "ff07d780-2531-4728-9432-bd786652ad51",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "filtering",
           "strings"
@@ -67,7 +67,7 @@
         "uuid": "cd829c1c-8e35-4cf7-a47e-3b394a036637",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "algorithms",
           "strings",
@@ -80,7 +80,7 @@
         "uuid": "b5363091-1350-428f-b709-550f9352d562",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "math"
         ]
@@ -91,7 +91,7 @@
         "uuid": "c26876c4-060e-4870-b20c-a4a3ebbfcf7c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "conditionals",
           "strings"
@@ -103,7 +103,7 @@
         "uuid": "5f6ed6d3-fd66-406a-9a92-544745a5e4ee",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "algorithms",
           "strings",
@@ -123,7 +123,7 @@
           "numbers",
           "math-operators"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "gigasecond",
@@ -136,7 +136,7 @@
           "datetimes",
           "numbers"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "hello-world",
@@ -144,7 +144,7 @@
         "uuid": "a3da97d9-8e55-47a2-ba80-7446ee8ddaa9",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "strings"
         ]
@@ -163,7 +163,7 @@
           "constructors",
           "numbers"
         ],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "lists"
         ]
@@ -174,7 +174,7 @@
         "uuid": "9b1ce07f-05fb-4d01-b4cd-cf7a8799db2f",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "conditionals",
           "integers"
@@ -192,7 +192,7 @@
           "integers",
           "strings"
         ],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "arrays"
         ]
@@ -209,7 +209,7 @@
           "strings",
           "numbers"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "resistor-color-trio",
@@ -224,7 +224,7 @@
           "numbers",
           "string-formatting"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "reverse-string",
@@ -232,7 +232,7 @@
         "uuid": "af6ae113-35b5-45a2-bf24-27381adf5c6f",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "strings"
         ]
@@ -251,7 +251,7 @@
           "strings",
           "exceptions"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "series",
@@ -270,7 +270,7 @@
           "for-loops",
           "exceptions"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "space-age",
@@ -286,7 +286,7 @@
           "constructors",
           "numbers"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "sum-of-multiples",
@@ -303,7 +303,7 @@
           "foreach-loops",
           "if-statements"
         ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "two-fer",
@@ -317,7 +317,7 @@
           "optional-parameters",
           "string-interpolation"
         ],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "optional_values",
           "strings"
@@ -506,7 +506,7 @@
         "uuid": "2523e11e-3a9e-4936-9cbb-37f53a6d90cb",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
+        "difficulty": 2,
         "status": "deprecated"
       },
       {
@@ -522,7 +522,7 @@
           "numbers",
           "for-loops"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "bottle-song",
@@ -537,7 +537,7 @@
           "numbers",
           "for-loops"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "dnd-character",
@@ -554,7 +554,7 @@
           "numbers",
           "constructors"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "error-handling",
@@ -571,7 +571,7 @@
           "resource-cleanup",
           "numbers"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "grade-school",
@@ -587,7 +587,7 @@
           "enumerables",
           "ordering"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "isogram",
@@ -603,7 +603,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "perfect-numbers",
@@ -617,7 +617,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "phone-number",
@@ -625,7 +625,7 @@
         "uuid": "d620068b-b36f-464a-ba78-82e1f8532c53",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
+        "difficulty": 2,
         "topics": [
           "parsing",
           "transforming"
@@ -644,7 +644,7 @@
           "while-loops",
           "arrays"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "proverb",
@@ -658,7 +658,7 @@
           "arrays",
           "for-loops"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "queen-attack",
@@ -676,7 +676,7 @@
           "math-operators",
           "exceptions"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "robot-name",
@@ -693,7 +693,7 @@
           "classes",
           "generic-types"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "robot-simulator",
@@ -712,7 +712,7 @@
           "chars",
           "switch-statements"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "scrabble-score",
@@ -725,7 +725,7 @@
           "numbers",
           "strings"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "secret-handshake",
@@ -739,7 +739,7 @@
           "bit-manipulation",
           "arrays"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "sieve",
@@ -753,7 +753,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "triangle",
@@ -768,7 +768,7 @@
           "if-statements",
           "booleans"
         ],
-        "difficulty": 3
+        "difficulty": 2
       },
       {
         "slug": "acronym",
@@ -784,7 +784,7 @@
           "strings",
           "booleans"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "affine-cipher",
@@ -799,7 +799,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "all-your-base",
@@ -807,7 +807,7 @@
         "uuid": "016ea49c-036b-44f7-909b-4c38aa62d636",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 5,
         "topics": [
           "integers",
           "math",
@@ -830,7 +830,7 @@
           "properties",
           "exceptions"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "circular-buffer",
@@ -848,7 +848,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "clock",
@@ -856,7 +856,7 @@
         "uuid": "12ce6363-d4dd-4ef0-82a6-388218aa71b7",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 5,
         "topics": [
           "classes",
           "equality"
@@ -874,7 +874,7 @@
           "string-formatting",
           "numbers"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "isbn-verifier",
@@ -889,7 +889,7 @@
           "chars",
           "booleans"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "largest-series-product",
@@ -907,7 +907,7 @@
           "for-loops",
           "exceptions"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "matrix",
@@ -924,7 +924,7 @@
           "numbers",
           "properties"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "meetup",
@@ -936,7 +936,7 @@
         "prerequisites": [
           "datetimes"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "prime-factors",
@@ -951,7 +951,7 @@
           "arrays",
           "while-loops"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "pythagorean-triplet",
@@ -967,7 +967,7 @@
           "enumerables",
           "generic-methods"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "rotational-cipher",
@@ -982,7 +982,7 @@
           "strings",
           "numbers"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "saddle-points",
@@ -999,7 +999,7 @@
           "generic-methods",
           "numbers"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "simple-linked-list",
@@ -1017,7 +1017,7 @@
           "properties",
           "numbers"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "twelve-days",
@@ -1032,7 +1032,7 @@
           "for-loops",
           "string-formatting"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "word-count",
@@ -1048,7 +1048,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 4
+        "difficulty": 5
       },
       {
         "slug": "accumulate",
@@ -1441,7 +1441,7 @@
           "nullability",
           "exceptions"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "change",
@@ -1456,7 +1456,7 @@
           "arrays",
           "exceptions"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "pig-latin",
@@ -1468,7 +1468,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "rail-fence-cipher",
@@ -1483,7 +1483,7 @@
           "numbers",
           "strings"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "rest-api",
@@ -1497,7 +1497,7 @@
           "optional-parameters",
           "constructors"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "tournament",
@@ -1512,7 +1512,7 @@
           "strings",
           "string-formatting"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "transpose",
@@ -1525,7 +1525,7 @@
           "strings",
           "for-loops"
         ],
-        "difficulty": 6
+        "difficulty": 5
       },
       {
         "slug": "diffie-hellman",
@@ -1541,7 +1541,7 @@
           "big-integers",
           "math-operators"
         ],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
         "slug": "poker",
@@ -1557,7 +1557,7 @@
           "ordering",
           "if-statements"
         ],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
         "slug": "rectangles",
@@ -1574,7 +1574,7 @@
           "for-loops",
           "if-statements"
         ],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
         "slug": "variable-length-quantity",
@@ -1591,7 +1591,7 @@
           "while-loops",
           "exceptions"
         ],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
         "slug": "wordy",
@@ -1606,7 +1606,7 @@
           "numbers",
           "exceptions"
         ],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
         "slug": "say",
@@ -1669,7 +1669,7 @@
           "classes",
           "equality"
         ],
-        "difficulty": 10
+        "difficulty": 8
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -55,7 +55,7 @@
         "uuid": "ff07d780-2531-4728-9432-bd786652ad51",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 5,
         "topics": [
           "filtering",
           "strings"
@@ -67,7 +67,7 @@
         "uuid": "cd829c1c-8e35-4cf7-a47e-3b394a036637",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 5,
         "topics": [
           "algorithms",
           "strings",
@@ -91,7 +91,7 @@
         "uuid": "c26876c4-060e-4870-b20c-a4a3ebbfcf7c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 5,
         "topics": [
           "conditionals",
           "strings"
@@ -103,7 +103,7 @@
         "uuid": "5f6ed6d3-fd66-406a-9a92-544745a5e4ee",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 5,
         "topics": [
           "algorithms",
           "strings",
@@ -358,7 +358,7 @@
         "uuid": "c867b7c0-3810-40c5-9d71-5763f2e28505",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2
+        "difficulty": 5
       },
       {
         "slug": "darts",
@@ -440,7 +440,7 @@
         "uuid": "5734890a-67af-4eaf-8c78-7d7580b8db70",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2
+        "difficulty": 5
       },
       {
         "slug": "nucleotide-count",
@@ -1066,7 +1066,7 @@
           "enumerables",
           "extension-methods"
         ],
-        "difficulty": 5,
+        "difficulty": 2,
         "topics": [
           "extension_methods",
           "sequences",
@@ -1097,7 +1097,7 @@
         "uuid": "6ea6e17c-9dbb-45c5-ab70-362791e5dd60",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5
+        "difficulty": 8
       },
       {
         "slug": "flatten-array",

--- a/config.json
+++ b/config.json
@@ -38,6 +38,29 @@
   "exercises": {
     "practice": [
       {
+        "slug": "accumulate",
+        "name": "Accumulate",
+        "uuid": "b2e12f15-5cae-4848-9ee8-2e1b0992b69c",
+        "practices": [
+          "lambdas",
+          "foreach",
+          "yield"
+        ],
+        "prerequisites": [
+          "lambdas",
+          "generic-types",
+          "foreach",
+          "enumerables",
+          "extension-methods"
+        ],
+        "difficulty": 2,
+        "topics": [
+          "extension_methods",
+          "sequences",
+          "transforming"
+        ]
+      },
+      {
         "slug": "allergies",
         "name": "Allergies",
         "uuid": "0488d664-0386-4471-b569-01f847ec6054",
@@ -47,280 +70,6 @@
         "topics": [
           "bitwise_operations",
           "filtering"
-        ]
-      },
-      {
-        "slug": "anagram",
-        "name": "Anagram",
-        "uuid": "ff07d780-2531-4728-9432-bd786652ad51",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
-      },
-      {
-        "slug": "atbash-cipher",
-        "name": "Atbash Cipher",
-        "uuid": "cd829c1c-8e35-4cf7-a47e-3b394a036637",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "binary",
-        "name": "Binary",
-        "uuid": "b5363091-1350-428f-b709-550f9352d562",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "math"
-        ]
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "c26876c4-060e-4870-b20c-a4a3ebbfcf7c",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "strings"
-        ]
-      },
-      {
-        "slug": "crypto-square",
-        "name": "Crypto Square",
-        "uuid": "5f6ed6d3-fd66-406a-9a92-544745a5e4ee",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "difference-of-squares",
-        "name": "Difference of Squares",
-        "uuid": "83d94c67-ce76-4676-a2fc-55284446ed3b",
-        "practices": [
-          "linq",
-          "math-operators",
-          "numbers"
-        ],
-        "prerequisites": [
-          "numbers",
-          "math-operators"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "gigasecond",
-        "name": "Gigasecond",
-        "uuid": "6b82f416-8878-4142-86fc-140f0c58989f",
-        "practices": [
-          "datetimes"
-        ],
-        "prerequisites": [
-          "datetimes",
-          "numbers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "hello-world",
-        "name": "Hello World",
-        "uuid": "a3da97d9-8e55-47a2-ba80-7446ee8ddaa9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "strings"
-        ]
-      },
-      {
-        "slug": "high-scores",
-        "name": "High Scores",
-        "uuid": "ace0e76d-d272-4349-badb-80720447b78a",
-        "practices": [
-          "lists",
-          "ordering"
-        ],
-        "prerequisites": [
-          "lists",
-          "ordering",
-          "constructors",
-          "numbers"
-        ],
-        "difficulty": 2,
-        "topics": [
-          "lists"
-        ]
-      },
-      {
-        "slug": "leap",
-        "name": "Leap",
-        "uuid": "9b1ce07f-05fb-4d01-b4cd-cf7a8799db2f",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "integers"
-        ]
-      },
-      {
-        "slug": "resistor-color",
-        "name": "Resistor Color",
-        "uuid": "494268ff-654d-4376-a163-837c4ca3195f",
-        "practices": [
-          "arrays"
-        ],
-        "prerequisites": [
-          "arrays",
-          "integers",
-          "strings"
-        ],
-        "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
-      },
-      {
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
-        "uuid": "7fe3065f-da2f-472b-b274-688cefb1e8ab",
-        "practices": [
-          "arrays"
-        ],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "numbers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "resistor-color-trio",
-        "name": "Resistor Color Trio",
-        "uuid": "d222a3f9-1947-4010-b3db-bb365ad80cba",
-        "practices": [
-          "string-formatting"
-        ],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "numbers",
-          "string-formatting"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "reverse-string",
-        "name": "Reverse String",
-        "uuid": "af6ae113-35b5-45a2-bf24-27381adf5c6f",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "strings"
-        ]
-      },
-      {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "c61a915a-9b85-4dc9-9025-518cf11e52ee",
-        "practices": [
-          "chars",
-          "linq",
-          "exceptions"
-        ],
-        "prerequisites": [
-          "chars",
-          "strings",
-          "exceptions"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "series",
-        "name": "Series",
-        "uuid": "7623e6c5-a893-4646-bc3c-c3d770572e7a",
-        "practices": [
-          "arrays",
-          "yield",
-          "for-loops",
-          "exceptions"
-        ],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "numbers",
-          "for-loops",
-          "exceptions"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "space-age",
-        "name": "Space Age",
-        "uuid": "664f766d-3f96-49d7-8ef7-9c1be4406f84",
-        "practices": [
-          "floating-point-numbers",
-          "classes"
-        ],
-        "prerequisites": [
-          "floating-point-numbers",
-          "classes",
-          "constructors",
-          "numbers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "sum-of-multiples",
-        "name": "Sum of Multiples",
-        "uuid": "73799a06-b510-47e1-87a3-7496f2afc346",
-        "practices": [
-          "enumerables",
-          "foreach-loops",
-          "numbers"
-        ],
-        "prerequisites": [
-          "enumerables",
-          "numbers",
-          "foreach-loops",
-          "if-statements"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "two-fer",
-        "name": "Two Fer",
-        "uuid": "22176233-7668-4faf-8ecc-f24a4c766307",
-        "practices": [
-          "optional-parameters",
-          "string-interpolation"
-        ],
-        "prerequisites": [
-          "optional-parameters",
-          "string-interpolation"
-        ],
-        "difficulty": 2,
-        "topics": [
-          "optional_values",
-          "strings"
         ]
       },
       {
@@ -334,6 +83,56 @@
           "numbers",
           "booleans",
           "casting"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "beer-song",
+        "name": "Beer Song",
+        "uuid": "2523e11e-3a9e-4936-9cbb-37f53a6d90cb",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "status": "deprecated"
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "b5363091-1350-428f-b709-550f9352d562",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "math"
+        ]
+      },
+      {
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "uuid": "85ba3b9b-ea14-4032-a7e5-45e911e0e5fd",
+        "practices": [
+          "arrays",
+          "for-loops"
+        ],
+        "prerequisites": [
+          "arrays",
+          "numbers",
+          "for-loops"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "bottle-song",
+        "name": "Bottle Song",
+        "uuid": "7495b54e-0c0c-4e1f-af6a-f367402483b2",
+        "practices": [
+          "switch-statements",
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "for-loops"
         ],
         "difficulty": 2
       },
@@ -353,12 +152,21 @@
         ]
       },
       {
-        "slug": "game-of-life",
-        "name": "Conway's Game of Life",
-        "uuid": "c867b7c0-3810-40c5-9d71-5763f2e28505",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
+        "slug": "dnd-character",
+        "name": "D&D Character",
+        "uuid": "dc8c3579-87bb-4730-aafa-fd0c01955250",
+        "practices": [
+          "randomness",
+          "constructors"
+        ],
+        "prerequisites": [
+          "randomness",
+          "classes",
+          "properties",
+          "numbers",
+          "constructors"
+        ],
+        "difficulty": 2
       },
       {
         "slug": "darts",
@@ -375,11 +183,43 @@
         "difficulty": 2
       },
       {
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "uuid": "83d94c67-ce76-4676-a2fc-55284446ed3b",
+        "practices": [
+          "linq",
+          "math-operators",
+          "numbers"
+        ],
+        "prerequisites": [
+          "numbers",
+          "math-operators"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "eliuds-eggs",
         "name": "Eliud's Eggs",
         "uuid": "fdb2a717-08d5-4f2a-bd53-fba6fe7c85db",
         "practices": [],
         "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "error-handling",
+        "name": "Error Handling",
+        "uuid": "09809c99-6fb9-4b7e-81b8-f069f79b0b0a",
+        "practices": [
+          "exceptions",
+          "casting",
+          "resource-cleanup"
+        ],
+        "prerequisites": [
+          "exceptions",
+          "casting",
+          "resource-cleanup",
+          "numbers"
+        ],
         "difficulty": 2
       },
       {
@@ -394,6 +234,35 @@
           "strings",
           "numbers",
           "dictionaries"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "6b82f416-8878-4142-86fc-140f0c58989f",
+        "practices": [
+          "datetimes"
+        ],
+        "prerequisites": [
+          "datetimes",
+          "numbers"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "e017f9e9-d928-43d1-b69f-5176d4d93785",
+        "practices": [
+          "dictionaries",
+          "ordering"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "enumerables",
+          "ordering"
         ],
         "difficulty": 2
       },
@@ -435,12 +304,62 @@
         ]
       },
       {
-        "slug": "nth-prime",
-        "name": "Nth Prime",
-        "uuid": "5734890a-67af-4eaf-8c78-7d7580b8db70",
+        "slug": "hello-world",
+        "name": "Hello World",
+        "uuid": "a3da97d9-8e55-47a2-ba80-7446ee8ddaa9",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5
+        "difficulty": 2,
+        "topics": [
+          "strings"
+        ]
+      },
+      {
+        "slug": "high-scores",
+        "name": "High Scores",
+        "uuid": "ace0e76d-d272-4349-badb-80720447b78a",
+        "practices": [
+          "lists",
+          "ordering"
+        ],
+        "prerequisites": [
+          "lists",
+          "ordering",
+          "constructors",
+          "numbers"
+        ],
+        "difficulty": 2,
+        "topics": [
+          "lists"
+        ]
+      },
+      {
+        "slug": "isogram",
+        "name": "Isogram",
+        "uuid": "ffa3cdb7-5cc8-4583-b6b1-e17f18db2b5d",
+        "practices": [
+          "chars",
+          "strings",
+          "sets"
+        ],
+        "prerequisites": [
+          "chars",
+          "strings",
+          "booleans"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "leap",
+        "name": "Leap",
+        "uuid": "9b1ce07f-05fb-4d01-b4cd-cf7a8799db2f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "conditionals",
+          "integers"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -464,135 +383,6 @@
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "7db2492a-2d20-4be3-af4a-c9fad183c752",
-        "practices": [
-          "chars",
-          "strings",
-          "sets"
-        ],
-        "prerequisites": [
-          "chars",
-          "strings",
-          "booleans"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "raindrops",
-        "name": "Raindrops",
-        "uuid": "36d91bd3-0cdc-4e53-94bf-4b9a797b596e",
-        "practices": [
-          "if-statements",
-          "casting"
-        ],
-        "prerequisites": [
-          "strings",
-          "if-statements",
-          "numbers",
-          "casting"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "square-root",
-        "name": "Square Root",
-        "uuid": "5704628e-f23f-4867-ae95-63151fbbc97f",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "beer-song",
-        "name": "Beer Song",
-        "uuid": "2523e11e-3a9e-4936-9cbb-37f53a6d90cb",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "deprecated"
-      },
-      {
-        "slug": "binary-search",
-        "name": "Binary Search",
-        "uuid": "85ba3b9b-ea14-4032-a7e5-45e911e0e5fd",
-        "practices": [
-          "arrays",
-          "for-loops"
-        ],
-        "prerequisites": [
-          "arrays",
-          "numbers",
-          "for-loops"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "bottle-song",
-        "name": "Bottle Song",
-        "uuid": "7495b54e-0c0c-4e1f-af6a-f367402483b2",
-        "practices": [
-          "switch-statements",
-          "string-formatting"
-        ],
-        "prerequisites": [
-          "strings",
-          "numbers",
-          "for-loops"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "dnd-character",
-        "name": "D&D Character",
-        "uuid": "dc8c3579-87bb-4730-aafa-fd0c01955250",
-        "practices": [
-          "randomness",
-          "constructors"
-        ],
-        "prerequisites": [
-          "randomness",
-          "classes",
-          "properties",
-          "numbers",
-          "constructors"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "error-handling",
-        "name": "Error Handling",
-        "uuid": "09809c99-6fb9-4b7e-81b8-f069f79b0b0a",
-        "practices": [
-          "exceptions",
-          "casting",
-          "resource-cleanup"
-        ],
-        "prerequisites": [
-          "exceptions",
-          "casting",
-          "resource-cleanup",
-          "numbers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "grade-school",
-        "name": "Grade School",
-        "uuid": "e017f9e9-d928-43d1-b69f-5176d4d93785",
-        "practices": [
-          "dictionaries",
-          "ordering"
-        ],
-        "prerequisites": [
-          "strings",
-          "numbers",
-          "enumerables",
-          "ordering"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "isogram",
-        "name": "Isogram",
-        "uuid": "ffa3cdb7-5cc8-4583-b6b1-e17f18db2b5d",
         "practices": [
           "chars",
           "strings",
@@ -679,6 +469,95 @@
         "difficulty": 2
       },
       {
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "uuid": "36d91bd3-0cdc-4e53-94bf-4b9a797b596e",
+        "practices": [
+          "if-statements",
+          "casting"
+        ],
+        "prerequisites": [
+          "strings",
+          "if-statements",
+          "numbers",
+          "casting"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "494268ff-654d-4376-a163-837c4ca3195f",
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "integers",
+          "strings"
+        ],
+        "difficulty": 2,
+        "topics": [
+          "arrays"
+        ]
+      },
+      {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "7fe3065f-da2f-472b-b274-688cefb1e8ab",
+        "practices": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "d222a3f9-1947-4010-b3db-bb365ad80cba",
+        "practices": [
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers",
+          "string-formatting"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "af6ae113-35b5-45a2-bf24-27381adf5c6f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "strings"
+        ]
+      },
+      {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "c61a915a-9b85-4dc9-9025-518cf11e52ee",
+        "practices": [
+          "chars",
+          "linq",
+          "exceptions"
+        ],
+        "prerequisites": [
+          "chars",
+          "strings",
+          "exceptions"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "robot-name",
         "name": "Robot Name",
         "uuid": "687037f7-bce0-4256-bcfd-1dda8bf0c401",
@@ -742,6 +621,25 @@
         "difficulty": 2
       },
       {
+        "slug": "series",
+        "name": "Series",
+        "uuid": "7623e6c5-a893-4646-bc3c-c3d770572e7a",
+        "practices": [
+          "arrays",
+          "yield",
+          "for-loops",
+          "exceptions"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers",
+          "for-loops",
+          "exceptions"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "sieve",
         "name": "Sieve",
         "uuid": "69846818-29ff-4293-84c2-49e62ee8dc34",
@@ -752,6 +650,47 @@
           "arrays",
           "numbers",
           "exceptions"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "space-age",
+        "name": "Space Age",
+        "uuid": "664f766d-3f96-49d7-8ef7-9c1be4406f84",
+        "practices": [
+          "floating-point-numbers",
+          "classes"
+        ],
+        "prerequisites": [
+          "floating-point-numbers",
+          "classes",
+          "constructors",
+          "numbers"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "5704628e-f23f-4867-ae95-63151fbbc97f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "sum-of-multiples",
+        "name": "Sum of Multiples",
+        "uuid": "73799a06-b510-47e1-87a3-7496f2afc346",
+        "practices": [
+          "enumerables",
+          "foreach-loops",
+          "numbers"
+        ],
+        "prerequisites": [
+          "enumerables",
+          "numbers",
+          "foreach-loops",
+          "if-statements"
         ],
         "difficulty": 2
       },
@@ -769,6 +708,24 @@
           "booleans"
         ],
         "difficulty": 2
+      },
+      {
+        "slug": "two-fer",
+        "name": "Two Fer",
+        "uuid": "22176233-7668-4faf-8ecc-f24a4c766307",
+        "practices": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
+        "prerequisites": [
+          "optional-parameters",
+          "string-interpolation"
+        ],
+        "difficulty": 2,
+        "topics": [
+          "optional_values",
+          "strings"
+        ]
       },
       {
         "slug": "acronym",
@@ -815,6 +772,31 @@
         ]
       },
       {
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "ff07d780-2531-4728-9432-bd786652ad51",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "filtering",
+          "strings"
+        ]
+      },
+      {
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "cd829c1c-8e35-4cf7-a47e-3b394a036637",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "strings",
+          "transforming"
+        ]
+      },
+      {
         "slug": "bank-account",
         "name": "Bank Account",
         "uuid": "1bbf5277-8fdf-411c-be19-ef19b6756246",
@@ -828,6 +810,67 @@
           "floating-point-numbers",
           "classes",
           "properties",
+          "exceptions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "c26876c4-060e-4870-b20c-a4a3ebbfcf7c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
+      },
+      {
+        "slug": "book-store",
+        "name": "Book Store",
+        "uuid": "4555cf8b-e800-494e-bc23-61f9428c900b",
+        "practices": [
+          "linq",
+          "for-loops",
+          "floating-point-numbers",
+          "recursion"
+        ],
+        "prerequisites": [
+          "floating-point-numbers",
+          "numbers",
+          "enumerables",
+          "for-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "bowling",
+        "name": "Bowling",
+        "uuid": "7d306a39-c748-4372-8ad6-eb9ff1d42a8b",
+        "practices": [
+          "nullability",
+          "classes"
+        ],
+        "prerequisites": [
+          "numbers",
+          "classes",
+          "nullability",
+          "exceptions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "change",
+        "name": "Change",
+        "uuid": "4b4197d2-8123-4474-8c32-1191c1f9b5cd",
+        "practices": [
+          "exceptions",
+          "linq"
+        ],
+        "prerequisites": [
+          "numbers",
+          "arrays",
           "exceptions"
         ],
         "difficulty": 5
@@ -863,241 +906,25 @@
         ]
       },
       {
-        "slug": "house",
-        "name": "House",
-        "uuid": "e191cff0-b845-48f0-9ac9-daae63af9e8a",
-        "practices": [
-          "string-formatting"
-        ],
-        "prerequisites": [
-          "strings",
-          "string-formatting",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "isbn-verifier",
-        "name": "ISBN Verifier",
-        "uuid": "c9151160-d2e8-4c54-9191-04644d913cd6",
-        "practices": [
-          "chars",
-          "regular-expressions"
-        ],
-        "prerequisites": [
-          "strings",
-          "chars",
-          "booleans"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "largest-series-product",
-        "name": "Largest Series Product",
-        "uuid": "19675f15-ff61-41e9-8610-c27edaefde04",
-        "practices": [
-          "integral-numbers",
-          "math-operators"
-        ],
-        "prerequisites": [
-          "integral-numbers",
-          "math-operators",
-          "strings",
-          "chars",
-          "for-loops",
-          "exceptions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "matrix",
-        "name": "Matrix",
-        "uuid": "2d9a1b92-9315-49cb-9e47-cff0caffe8a4",
-        "practices": [
-          "properties",
-          "classes",
-          "arrays"
-        ],
-        "prerequisites": [
-          "arrays",
-          "classes",
-          "numbers",
-          "properties"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "meetup",
-        "name": "Meetup",
-        "uuid": "2a099206-450b-4ef8-a282-66ec460aa286",
-        "practices": [
-          "datetimes"
-        ],
-        "prerequisites": [
-          "datetimes"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "prime-factors",
-        "name": "Prime Factors",
-        "uuid": "551510bc-817d-4145-b974-f9149f7e1c5e",
-        "practices": [
-          "integral-numbers",
-          "while-loops"
-        ],
-        "prerequisites": [
-          "integral-numbers",
-          "arrays",
-          "while-loops"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "pythagorean-triplet",
-        "name": "Pythagorean Triplet",
-        "uuid": "ceb811d0-3aae-4517-9e37-1eca5ba07c39",
-        "practices": [
-          "tuples",
-          "generic-methods"
-        ],
-        "prerequisites": [
-          "tuples",
-          "numbers",
-          "enumerables",
-          "generic-methods"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "rotational-cipher",
-        "name": "Rotational Cipher",
-        "uuid": "bced4d03-740d-4d71-8e08-7a47f6f0d6af",
-        "practices": [
-          "chars",
-          "strings"
-        ],
-        "prerequisites": [
-          "chars",
-          "strings",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "saddle-points",
-        "name": "Saddle Points",
-        "uuid": "cbdb6929-d1cb-416a-b38a-8eda20401deb",
-        "practices": [
-          "multi-dimensional-arrays",
-          "tuples"
-        ],
-        "prerequisites": [
-          "multi-dimensional-arrays",
-          "tuples",
-          "enumerables",
-          "generic-methods",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "simple-linked-list",
-        "name": "Simple Linked List",
-        "uuid": "ed632f85-3488-4cec-bbbb-19582a380c1f",
-        "practices": [
-          "interfaces",
-          "generic-types",
-          "properties",
-          "enumerables"
-        ],
-        "prerequisites": [
-          "interfaces",
-          "generic-types",
-          "properties",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "twelve-days",
-        "name": "Twelve Days",
-        "uuid": "a3845cd0-061c-4c1b-a687-45a28a9504a0",
-        "practices": [
-          "string-formatting"
-        ],
-        "prerequisites": [
-          "strings",
-          "numbers",
-          "for-loops",
-          "string-formatting"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "word-count",
-        "name": "Word Count",
-        "uuid": "af99f598-996e-4a03-ba5d-5cea5de96e0c",
-        "practices": [
-          "dictionaries",
-          "regular-expressions"
-        ],
-        "prerequisites": [
-          "strings",
-          "dictionaries",
-          "numbers",
-          "exceptions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "accumulate",
-        "name": "Accumulate",
-        "uuid": "b2e12f15-5cae-4848-9ee8-2e1b0992b69c",
-        "practices": [
-          "lambdas",
-          "foreach",
-          "yield"
-        ],
-        "prerequisites": [
-          "lambdas",
-          "generic-types",
-          "foreach",
-          "enumerables",
-          "extension-methods"
-        ],
-        "difficulty": 2,
-        "topics": [
-          "extension_methods",
-          "sequences",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "book-store",
-        "name": "Book Store",
-        "uuid": "4555cf8b-e800-494e-bc23-61f9428c900b",
-        "practices": [
-          "linq",
-          "for-loops",
-          "floating-point-numbers",
-          "recursion"
-        ],
-        "prerequisites": [
-          "floating-point-numbers",
-          "numbers",
-          "enumerables",
-          "for-loops"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "diamond",
-        "name": "Diamond",
-        "uuid": "6ea6e17c-9dbb-45c5-ab70-362791e5dd60",
+        "slug": "game-of-life",
+        "name": "Conway's Game of Life",
+        "uuid": "c867b7c0-3810-40c5-9d71-5763f2e28505",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 8
+        "difficulty": 5
+      },
+      {
+        "slug": "crypto-square",
+        "name": "Crypto Square",
+        "uuid": "5f6ed6d3-fd66-406a-9a92-544745a5e4ee",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "flatten-array",
@@ -1163,6 +990,53 @@
           "flag-enums",
           "if-statements",
           "string-formatting"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "house",
+        "name": "House",
+        "uuid": "e191cff0-b845-48f0-9ac9-daae63af9e8a",
+        "practices": [
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "strings",
+          "string-formatting",
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "isbn-verifier",
+        "name": "ISBN Verifier",
+        "uuid": "c9151160-d2e8-4c54-9191-04644d913cd6",
+        "practices": [
+          "chars",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "chars",
+          "booleans"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "largest-series-product",
+        "name": "Largest Series Product",
+        "uuid": "19675f15-ff61-41e9-8610-c27edaefde04",
+        "practices": [
+          "integral-numbers",
+          "math-operators"
+        ],
+        "prerequisites": [
+          "integral-numbers",
+          "math-operators",
+          "strings",
+          "chars",
+          "for-loops",
+          "exceptions"
         ],
         "difficulty": 5
       },
@@ -1246,6 +1120,35 @@
         "difficulty": 5
       },
       {
+        "slug": "matrix",
+        "name": "Matrix",
+        "uuid": "2d9a1b92-9315-49cb-9e47-cff0caffe8a4",
+        "practices": [
+          "properties",
+          "classes",
+          "arrays"
+        ],
+        "prerequisites": [
+          "arrays",
+          "classes",
+          "numbers",
+          "properties"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "2a099206-450b-4ef8-a282-66ec460aa286",
+        "practices": [
+          "datetimes"
+        ],
+        "prerequisites": [
+          "datetimes"
+        ],
+        "difficulty": 5
+      },
+      {
         "slug": "minesweeper",
         "name": "Minesweeper",
         "uuid": "4b2add72-b584-4f37-b401-61bf540187b6",
@@ -1253,6 +1156,14 @@
         "prerequisites": [],
         "difficulty": 5,
         "status": "deprecated"
+      },
+      {
+        "slug": "nth-prime",
+        "name": "Nth Prime",
+        "uuid": "5734890a-67af-4eaf-8c78-7d7580b8db70",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
       },
       {
         "slug": "ocr-numbers",
@@ -1289,11 +1200,83 @@
         "difficulty": 5
       },
       {
+        "slug": "pig-latin",
+        "name": "Pig Latin",
+        "uuid": "65780c09-7730-447d-ae61-43f19283be85",
+        "practices": [
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "prime-factors",
+        "name": "Prime Factors",
+        "uuid": "551510bc-817d-4145-b974-f9149f7e1c5e",
+        "practices": [
+          "integral-numbers",
+          "while-loops"
+        ],
+        "prerequisites": [
+          "integral-numbers",
+          "arrays",
+          "while-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "pythagorean-triplet",
+        "name": "Pythagorean Triplet",
+        "uuid": "ceb811d0-3aae-4517-9e37-1eca5ba07c39",
+        "practices": [
+          "tuples",
+          "generic-methods"
+        ],
+        "prerequisites": [
+          "tuples",
+          "numbers",
+          "enumerables",
+          "generic-methods"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "rail-fence-cipher",
+        "name": "Rail Fence Cipher",
+        "uuid": "b8645a9c-bd7e-4e57-81b4-079b5e0c3bb0",
+        "practices": [
+          "constructors"
+        ],
+        "prerequisites": [
+          "classes",
+          "constructors",
+          "numbers",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
         "slug": "relative-distance",
         "name": "Relative Distance",
         "uuid": "ed5b4ff7-c787-4907-8a66-62920a5c5022",
         "practices": [],
         "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "rest-api",
+        "name": "REST API",
+        "uuid": "31b40119-cb73-420c-aec9-d920450966df",
+        "practices": [
+          "optional-parameters"
+        ],
+        "prerequisites": [
+          "strings",
+          "optional-parameters",
+          "constructors"
+        ],
         "difficulty": 5
       },
       {
@@ -1314,6 +1297,21 @@
         "difficulty": 5
       },
       {
+        "slug": "rotational-cipher",
+        "name": "Rotational Cipher",
+        "uuid": "bced4d03-740d-4d71-8e08-7a47f6f0d6af",
+        "practices": [
+          "chars",
+          "strings"
+        ],
+        "prerequisites": [
+          "chars",
+          "strings",
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
         "slug": "run-length-encoding",
         "name": "Run-Length Encoding",
         "uuid": "b829510c-85d4-49cc-9598-047c93933a94",
@@ -1325,6 +1323,23 @@
           "if-statements",
           "foreach-loops",
           "booleans"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "saddle-points",
+        "name": "Saddle Points",
+        "uuid": "cbdb6929-d1cb-416a-b38a-8eda20401deb",
+        "practices": [
+          "multi-dimensional-arrays",
+          "tuples"
+        ],
+        "prerequisites": [
+          "multi-dimensional-arrays",
+          "tuples",
+          "enumerables",
+          "generic-methods",
+          "numbers"
         ],
         "difficulty": 5
       },
@@ -1352,6 +1367,24 @@
           "properties",
           "randomness",
           "for-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "simple-linked-list",
+        "name": "Simple Linked List",
+        "uuid": "ed632f85-3488-4cec-bbbb-19582a380c1f",
+        "practices": [
+          "interfaces",
+          "generic-types",
+          "properties",
+          "enumerables"
+        ],
+        "prerequisites": [
+          "interfaces",
+          "generic-types",
+          "properties",
+          "numbers"
         ],
         "difficulty": 5
       },
@@ -1392,114 +1425,6 @@
         "difficulty": 5
       },
       {
-        "slug": "tree-building",
-        "name": "Tree Building",
-        "uuid": "a135ee70-f24c-4b7c-8257-ace42d4f1c3b",
-        "practices": [
-          "properties",
-          "classes",
-          "enumerables"
-        ],
-        "prerequisites": [
-          "classes",
-          "properties",
-          "exceptions",
-          "foreach-loops",
-          "numbers",
-          "booleans",
-          "enumerables",
-          "generic-methods"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "yacht",
-        "name": "Yacht",
-        "uuid": "043776f5-cc8a-4b34-9701-c1569610a995",
-        "practices": [
-          "enums",
-          "linq"
-        ],
-        "prerequisites": [
-          "enums",
-          "arrays",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "bowling",
-        "name": "Bowling",
-        "uuid": "7d306a39-c748-4372-8ad6-eb9ff1d42a8b",
-        "practices": [
-          "nullability",
-          "classes"
-        ],
-        "prerequisites": [
-          "numbers",
-          "classes",
-          "nullability",
-          "exceptions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "change",
-        "name": "Change",
-        "uuid": "4b4197d2-8123-4474-8c32-1191c1f9b5cd",
-        "practices": [
-          "exceptions",
-          "linq"
-        ],
-        "prerequisites": [
-          "numbers",
-          "arrays",
-          "exceptions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "pig-latin",
-        "name": "Pig Latin",
-        "uuid": "65780c09-7730-447d-ae61-43f19283be85",
-        "practices": [
-          "regular-expressions"
-        ],
-        "prerequisites": [
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "rail-fence-cipher",
-        "name": "Rail Fence Cipher",
-        "uuid": "b8645a9c-bd7e-4e57-81b4-079b5e0c3bb0",
-        "practices": [
-          "constructors"
-        ],
-        "prerequisites": [
-          "classes",
-          "constructors",
-          "numbers",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "rest-api",
-        "name": "REST API",
-        "uuid": "31b40119-cb73-420c-aec9-d920450966df",
-        "practices": [
-          "optional-parameters"
-        ],
-        "prerequisites": [
-          "strings",
-          "optional-parameters",
-          "constructors"
-        ],
-        "difficulty": 5
-      },
-      {
         "slug": "tournament",
         "name": "Tournament",
         "uuid": "a15aad1a-b578-46f9-b720-7d448da0459c",
@@ -1526,6 +1451,81 @@
           "for-loops"
         ],
         "difficulty": 5
+      },
+      {
+        "slug": "tree-building",
+        "name": "Tree Building",
+        "uuid": "a135ee70-f24c-4b7c-8257-ace42d4f1c3b",
+        "practices": [
+          "properties",
+          "classes",
+          "enumerables"
+        ],
+        "prerequisites": [
+          "classes",
+          "properties",
+          "exceptions",
+          "foreach-loops",
+          "numbers",
+          "booleans",
+          "enumerables",
+          "generic-methods"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "twelve-days",
+        "name": "Twelve Days",
+        "uuid": "a3845cd0-061c-4c1b-a687-45a28a9504a0",
+        "practices": [
+          "string-formatting"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "for-loops",
+          "string-formatting"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "word-count",
+        "name": "Word Count",
+        "uuid": "af99f598-996e-4a03-ba5d-5cea5de96e0c",
+        "practices": [
+          "dictionaries",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "dictionaries",
+          "numbers",
+          "exceptions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "yacht",
+        "name": "Yacht",
+        "uuid": "043776f5-cc8a-4b34-9701-c1569610a995",
+        "practices": [
+          "enums",
+          "linq"
+        ],
+        "prerequisites": [
+          "enums",
+          "arrays",
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "diamond",
+        "name": "Diamond",
+        "uuid": "6ea6e17c-9dbb-45c5-ab70-362791e5dd60",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 8
       },
       {
         "slug": "diffie-hellman",
@@ -1577,38 +1577,6 @@
         "difficulty": 8
       },
       {
-        "slug": "variable-length-quantity",
-        "name": "Variable Length Quantity",
-        "uuid": "428f8080-f804-4433-b0c9-9cc1e7f82fa1",
-        "practices": [
-          "integral-numbers",
-          "bit-manipulation"
-        ],
-        "prerequisites": [
-          "integral-numbers",
-          "arrays",
-          "bit-manipulation",
-          "while-loops",
-          "exceptions"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "wordy",
-        "name": "Wordy",
-        "uuid": "542820e5-43a9-4c05-93c2-e3e07329f380",
-        "practices": [
-          "switch-statements",
-          "regular-expressions"
-        ],
-        "prerequisites": [
-          "strings",
-          "numbers",
-          "exceptions"
-        ],
-        "difficulty": 8
-      },
-      {
         "slug": "say",
         "name": "Say",
         "uuid": "f0155d4f-052f-4d13-a3dd-67777ef3520a",
@@ -1639,6 +1607,38 @@
           "constructors",
           "properties",
           "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "variable-length-quantity",
+        "name": "Variable Length Quantity",
+        "uuid": "428f8080-f804-4433-b0c9-9cc1e7f82fa1",
+        "practices": [
+          "integral-numbers",
+          "bit-manipulation"
+        ],
+        "prerequisites": [
+          "integral-numbers",
+          "arrays",
+          "bit-manipulation",
+          "while-loops",
+          "exceptions"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "wordy",
+        "name": "Wordy",
+        "uuid": "542820e5-43a9-4c05-93c2-e3e07329f380",
+        "practices": [
+          "switch-statements",
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings",
+          "numbers",
+          "exceptions"
         ],
         "difficulty": 8
       },


### PR DESCRIPTION
All easy exercises are 2, all medium 5, and all hard 8.
I manually bumped a few exercises' difficulty, mainly to harder difficulties on par with the C# track.
Then I resorted the exercises by bucket and then lowercase name. That in turn required a tweak to the CI checking exercise order.