### PR TITLE
`ArgumentOutOfRangeException` should be checked in `all-your-base`

### DIFF
--- a/exercises/practice/all-your-base/.meta/Example.vb
+++ b/exercises/practice/all-your-base/.meta/Example.vb
@@ -3,12 +3,12 @@ Imports System.Collections.Generic
 
 Public Module AllYourBase
     Public Function Rebase(ByVal inputBase As Integer, ByVal inputDigits As Integer(), ByVal outputBase As Integer) As Integer()
-        If outputBase <= 1 OrElse inputBase <= 1 Then Throw New ArgumentException()
+        If outputBase <= 1 OrElse inputBase <= 1 Then Throw New ArgumentOutOfRangeException()
         Dim inputValue = 0
         Dim exponent = 0, place = inputDigits.Length - 1
 
         While exponent < inputDigits.Length
-            If inputDigits(place) < 0 OrElse inputDigits(place) >= inputBase Then Throw New ArgumentException()
+            If inputDigits(place) < 0 OrElse inputDigits(place) >= inputBase Then Throw New ArgumentOutOfRangeException()
             inputValue += inputDigits(place) * CInt(Math.Pow(inputBase, exponent))
             exponent += 1
             place -= 1

--- a/exercises/practice/all-your-base/AllYourBaseTests.vb
+++ b/exercises/practice/all-your-base/AllYourBaseTests.vb
@@ -126,7 +126,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 1
         Dim digits = {0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -134,7 +134,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 0
         Dim digits = Array.Empty(Of Integer)()
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -142,7 +142,7 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -150,7 +150,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, -1, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -158,7 +158,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 2, 1, 0, 1, 0}
         Dim outputBase = 10
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -166,7 +166,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1, 0, 1, 0, 1, 0}
         Dim outputBase = 1
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -174,7 +174,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 10
         Dim digits = {7}
         Dim outputBase = 0
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -182,7 +182,7 @@ Public Class AllYourBaseTests
         Dim inputBase = 2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
@@ -190,6 +190,6 @@ Public Class AllYourBaseTests
         Dim inputBase = -2
         Dim digits = {1}
         Dim outputBase = -7
-        Assert.Throws(Of ArgumentException)(Function() Rebase(inputBase, digits, outputBase))
+        Assert.Throws(Of ArgumentOutOfRangeException)(Function() Rebase(inputBase, digits, outputBase))
     End Sub
 End Class


### PR DESCRIPTION
Closes #143. Throwing ArgumentOutOfRangeException nudges the student towards best practices.