### PR TITLE
Resolve warnings from compiler

### DIFF
--- a/exercises/practice/change/.meta/Example.vb
+++ b/exercises/practice/change/.meta/Example.vb
@@ -12,7 +12,8 @@ Public Module Change
         fewestCoins(0) = Array.Empty(Of Integer)()
 
         For amount = 1 To target
-            Dim change As IEnumerable(Of Integer) = coins.Where(Function(coin) coin <= amount).[Select](Function(coin) fewestCoins(amount - coin).Append(coin)).OrderBy(Function(x) x.Count()).FirstOrDefault(Function(y) y.Sum() = amount)
+            Dim currentAmount = amount
+            Dim change As IEnumerable(Of Integer) = coins.Where(Function(coin) coin <= currentAmount).[Select](Function(coin) fewestCoins(currentAmount - coin).Append(coin)).OrderBy(Function(x) x.Count()).FirstOrDefault(Function(y) y.Sum() = currentAmount)
 
             If change Is Nothing Then
                 fewestCoins(amount) = New List(Of Integer)().ToArray()

--- a/exercises/practice/circular-buffer/.meta/Example.vb
+++ b/exercises/practice/circular-buffer/.meta/Example.vb
@@ -40,14 +40,6 @@ Public Class CircularBuffer(Of T)
     End Sub
 
     Private Sub DequeueHead()
-        CSharpImpl.__Assign(items, items.Skip(1).ToList())
+        items = items.Skip(1).ToList()
     End Sub
-
-    Private Class CSharpImpl
-        <Obsolete("Please refactor calling code to use normal Visual Basic assignment")>
-        Shared Function __Assign(Of T)(ByRef target As T, value As T) As T
-            target = value
-            Return value
-        End Function
-    End Class
 End Class

--- a/exercises/practice/list-ops/.meta/Example.vb
+++ b/exercises/practice/list-ops/.meta/Example.vb
@@ -47,7 +47,8 @@ Public Module ListOps
         Dim sublist As List(Of T) = Nothing
 
         For Each list In input
-            If CSharpImpl.__Assign(sublist, TryCast(list, List(Of T))) IsNot Nothing Then concatenated = Append(concatenated, sublist)
+            sublist = TryCast(list, List(Of T))
+            If sublist IsNot Nothing Then concatenated = Append(concatenated, sublist)
         Next
 
 
@@ -67,12 +68,4 @@ Public Module ListOps
 
         Return appended.ToList()
     End Function
-
-    Private Class CSharpImpl
-        <Obsolete("Please refactor calling code to use normal Visual Basic assignment")>
-        Shared Function __Assign(Of T)(ByRef target As T, value As T) As T
-            target = value
-            Return value
-        End Function
-    End Class
 End Module

--- a/exercises/practice/nth-prime/.meta/Example.vb
+++ b/exercises/practice/nth-prime/.meta/Example.vb
@@ -1,5 +1,5 @@
 Public Module NthPrime
-    Public Function Prime(ByVal number As Integer)
+    Public Function Prime(ByVal number As Integer) As Integer
         If number < 1 Then
             Throw New ArgumentOutOfRangeException(nameof(number), "There are no negative nth primes")
         End If
@@ -16,9 +16,11 @@ Public Module NthPrime
             End If
             candidate += 1
         End While
+
+        Throw New InvalidOperationException("unreachable")
     End Function
 
-    Private Function IsPrime(ByVal num As Integer)
+    Private Function IsPrime(ByVal num As Integer) As Boolean
         If num <= 1 Then
             Return False
         End If

--- a/exercises/practice/ocr-numbers/.meta/Example.vb
+++ b/exercises/practice/ocr-numbers/.meta/Example.vb
@@ -46,11 +46,19 @@ Public Module OcrNumbers
     End Function
 
     Private Function Cols(ByVal lines As String()) As Integer
-        Return If(lines(0).Length Mod CharacterWidth = 0, lines(0).Length / CharacterWidth, CSharpImpl.__Throw(Of Integer)(New ArgumentException()))
+        If lines(0).Length Mod CharacterWidth <> 0 Then
+            Throw New ArgumentException()
+        End If
+
+        Return lines(0).Length / CharacterWidth
     End Function
 
     Private Function Rows(ByVal lines As String()) As Integer
-        Return If(lines.Length Mod CharacterHeight = 0, lines.Length / CharacterHeight, CSharpImpl.__Throw(Of Integer)(New ArgumentException()))
+        If lines.Length Mod CharacterHeight <> 0 Then
+            Throw New ArgumentException()
+        End If
+
+        Return lines.Length / CharacterHeight
     End Function
 
     Private Function IsEmptyLine(ByVal line As String) As Boolean
@@ -82,11 +90,4 @@ Public Module OcrNumbers
                                                                         {" _ " & "|_|" & " _|" & "   ", "9"c},
                                                                         {"   " & "   " & "  ," & "   ", ","c}
 }
-
-    Private Class CSharpImpl
-        <Obsolete("Please refactor calling code to use normal throw statements")>
-        Shared Function __Throw(Of T)(ByVal e As Exception) As T
-            Throw e
-        End Function
-    End Class
 End Module


### PR DESCRIPTION
`change`
BC42324: loop iteration variable amount captured in lambdas

`circular-buffer`
BC40000: obsolete CSharpImpl.__Assign(...)
BC40048: nested helper type parameter T shadowed enclosing T

`list-ops`
BC40000: obsolete CSharpImpl.__Assign(...)

`ocr-numbers`
BC40000: obsolete CSharpImpl.__Throw(...)

`nth-prime`
BC42105: Function Prime did not return a value on all code paths.