### PR TITLE
Sync isbn-verifier with problem specifications

### DIFF
--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -30,6 +30,12 @@ description = "invalid character in isbn is not treated as zero"
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
 
+[8005b57f-f194-44ee-88d2-a77ac4142591]
+description = "only one check digit is allowed"
+
+[fdb14c99-4cf8-43c5-b06d-eb1638eff343]
+description = "X is not substituted by the value 10"
+
 [f6294e61-7e79-46b3-977b-f48789a4945b]
 description = "valid isbn without separating dashes"
 

--- a/exercises/practice/isbn-verifier/IsbnVerifierTests.vb
+++ b/exercises/practice/isbn-verifier/IsbnVerifierTests.vb
@@ -35,6 +35,16 @@ Public Class IsbnVerifierTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Only_one_check_digit_is_allowed()
+        Assert.False(IsValid("3-598-21508-96"))
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub X_is_not_substituted_by_the_value_10()
+        Assert.False(IsValid("3-598-2X507-5"))
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Valid_isbn_without_separating_dashes()
         Assert.True(IsValid("3598215088"))
     End Sub


### PR DESCRIPTION
Adds two canonical test cases missing from the isbn-verifier suite: 'only one check digit is allowed' and 'X is not substituted by the value 10'. Verified via ./bin/test.ps1 isbn-verifier - 21/21 tests pass. No changes to Example.vb needed since the existing solution already handles both cases correctly.

Closes #453