### PR TITLE
Sync crypto-square with problem specifications

### DIFF
--- a/exercises/practice/crypto-square/.meta/Example.vb
+++ b/exercises/practice/crypto-square/.meta/Example.vb
@@ -2,10 +2,11 @@ Imports System.Runtime.CompilerServices
 
 Friend Module Crypto
 	Public Function Ciphertext(plaintext As String) As String
-		If plaintext.Length = 0
+		Dim normalized = plaintext.Normalized()
+		If normalized.Length = 0
 			Return ""
 		Else
-			Return String.Join(" ", plaintext.Normalized().Rows().Columns())
+			Return String.Join(" ", normalized.Rows().Columns())
 		End If
 	End Function
 	

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "axtens",
-    "erikschierboom"
+    "erikschierboom",
+    "ManasDasri"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -11,6 +11,9 @@
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
 
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
+
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
 
@@ -26,5 +29,5 @@ description = "9 character plaintext results in 3 chunks of 3 characters"
 [a65d3fa1-9e09-43f9-bcec-7a672aec3eae]
 description = "8 character plaintext results in 3 chunks, the last one with a trailing space"
 
-[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
-description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
+[33fd914e-fa44-445b-8f38-ff8fbc9fe6e6]
+description = "54 character plaintext results in 8 chunks, the last two with trailing spaces"

--- a/exercises/practice/crypto-square/CryptoSquareTests.vb
+++ b/exercises/practice/crypto-square/CryptoSquareTests.vb
@@ -6,6 +6,12 @@ Public Class CryptoSquareTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub NormalizationResultsInEmptyPlaintext()
+        Dim plaintext = "... --- ..."
+        Assert.Equal("", Ciphertext(plaintext))
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Lowercase()
         Dim plaintext = "A"
         Assert.Equal("a", Ciphertext(plaintext))
@@ -36,7 +42,7 @@ Public Class CryptoSquareTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub FiftyFourCharacterPlaintextResultsInSevenChunksTheTwoWithTrailingSpaces()
+    Public Sub FiftyFourCharacterPlaintextResultsInEightChunksTheTwoWithTrailingSpaces()
         Dim plaintext = "If man was meant to stay on the ground, god would have given us roots."
         Assert.Equal("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", Ciphertext(plaintext))
     End Sub


### PR DESCRIPTION
Adds the missing 'normalization results in empty plaintext' canonical case and updates the reimplemented 54-character case (description corrected from 7 to 8 chunks, same input/expected values).

This also fixes a real bug in Example.vb: Ciphertext checked plaintext.Length (the raw input) before the empty-check, so inputs that normalize to an empty string (e.g. '... --- ...', all punctuation) skipped the early return and crashed trying to build rows/columns from nothing. Now it checks the normalized string's length instead.

Verified via pwsh ./bin/test.ps1 crypto-square - all tests pass.

Closes #434