### PR TITLE
Sync variable-length-quantity tests

### DIFF
--- a/exercises/practice/variable-length-quantity/.meta/tests.toml
+++ b/exercises/practice/variable-length-quantity/.meta/tests.toml
@@ -10,79 +10,94 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [35c9db2e-f781-4c52-b73b-8e76427defd0]
-description = "zero"
+description = "Encode a series of integers, producing a series of bytes. -> zero"
 
 [be44d299-a151-4604-a10e-d4b867f41540]
-description = "arbitrary single byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary single byte"
+
+[890bc344-cb80-45af-b316-6806a6971e81]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric single byte"
 
 [ea399615-d274-4af6-bbef-a1c23c9e1346]
-description = "largest single byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest single byte"
 
 [77b07086-bd3f-4882-8476-8dcafee79b1c]
-description = "smallest double byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest double byte"
 
 [63955a49-2690-4e22-a556-0040648d6b2d]
-description = "arbitrary double byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary double byte"
+
+[4977d113-251b-4d10-a3ad-2f5a7756bb58]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric double byte"
 
 [29da7031-0067-43d3-83a7-4f14b29ed97a]
-description = "largest double byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest double byte"
 
 [3345d2e3-79a9-4999-869e-d4856e3a8e01]
-description = "smallest triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest triple byte"
 
 [5df0bc2d-2a57-4300-a653-a75ee4bd0bee]
-description = "arbitrary triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary triple byte"
+
+[6731045f-1e00-4192-b5ae-98b22e17e9f7]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric triple byte"
 
 [f51d8539-312d-4db1-945c-250222c6aa22]
-description = "largest triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest triple byte"
 
 [da78228b-544f-47b7-8bfe-d16b35bbe570]
-description = "smallest quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest quadruple byte"
 
 [11ed3469-a933-46f1-996f-2231e05d7bb6]
-description = "arbitrary quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quadruple byte"
+
+[b45ef770-cbba-48c2-bd3c-c6362679516e]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric quadruple byte"
 
 [d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c]
-description = "largest quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest quadruple byte"
 
 [91a18b33-24e7-4bfb-bbca-eca78ff4fc47]
-description = "smallest quintuple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest quintuple byte"
 
 [5f34ff12-2952-4669-95fe-2d11b693d331]
-description = "arbitrary quintuple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quintuple byte"
+
+[9be46731-7cd5-415c-b960-48061cbc1154]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric quintuple byte"
 
 [7489694b-88c3-4078-9864-6fe802411009]
-description = "maximum 32-bit integer input"
+description = "Encode a series of integers, producing a series of bytes. -> maximum 32-bit integer input"
 
 [f9b91821-cada-4a73-9421-3c81d6ff3661]
-description = "two single-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> two single-byte values"
 
 [68694449-25d2-4974-ba75-fa7bb36db212]
-description = "two multi-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> two multi-byte values"
 
 [51a06b5c-de1b-4487-9a50-9db1b8930d85]
-description = "many multi-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> many multi-byte values"
 
 [baa73993-4514-4915-bac0-f7f585e0e59a]
-description = "one byte"
+description = "Decode a series of bytes, producing a series of integers. -> one byte"
 
 [72e94369-29f9-46f2-8c95-6c5b7a595aee]
-description = "two bytes"
+description = "Decode a series of bytes, producing a series of integers. -> two bytes"
 
 [df5a44c4-56f7-464e-a997-1db5f63ce691]
-description = "three bytes"
+description = "Decode a series of bytes, producing a series of integers. -> three bytes"
 
 [1bb58684-f2dc-450a-8406-1f3452aa1947]
-description = "four bytes"
+description = "Decode a series of bytes, producing a series of integers. -> four bytes"
 
 [cecd5233-49f1-4dd1-a41a-9840a40f09cd]
-description = "maximum 32-bit integer"
+description = "Decode a series of bytes, producing a series of integers. -> maximum 32-bit integer"
 
 [e7d74ba3-8b8e-4bcb-858d-d08302e15695]
-description = "incomplete sequence causes error"
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error"
 
 [aa378291-9043-4724-bc53-aca1b4a3fcb6]
-description = "incomplete sequence causes error, even if value is zero"
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error, even if value is zero"
 
 [a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee]
-description = "multiple values"
+description = "Decode a series of bytes, producing a series of integers. -> multiple values"

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTests.vb
@@ -16,6 +16,14 @@ Public Class VariableLengthQuantityTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Asymmetric_single_byte()
+        Dim integers = {&H53UI}
+        Dim expected = {&H53UI}
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_single_byte()
         Dim integers = {&H7FUI}
         Dim expected = {&H7FUI}
@@ -35,6 +43,14 @@ Public Class VariableLengthQuantityTests
     Public Sub Arbitrary_double_byte()
         Dim integers = {&H2000UI}
         Dim expected = {&HC0UI, &H0UI}
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Asymmetric_double_byte()
+        Dim integers = {&HADUI}
+        Dim expected = {&H81UI, &H2DUI}
         Dim result as IEnumerable(Of UInteger) = Encode(integers)
         Assert.Equal(expected, result)
     End Sub
@@ -64,6 +80,14 @@ Public Class VariableLengthQuantityTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Asymmetric_triple_byte()
+        Dim integers = {&H1D59CUI}
+        Dim expected = {&H87UI, &HABUI, &H1CUI}
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_triple_byte()
         Dim integers = {&H1FFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &H7FUI}
@@ -88,6 +112,14 @@ Public Class VariableLengthQuantityTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Asymmetric_quadruple_byte()
+        Dim integers = {&H357704UI}
+        Dim expected = {&H81UI, &HD5UI, &HEEUI, &H4UI}
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Largest_quadruple_byte()
         Dim integers = {&HFFFFFFFUI}
         Dim expected = {&HFFUI, &HFFUI, &HFFUI, &H7FUI}
@@ -107,6 +139,14 @@ Public Class VariableLengthQuantityTests
     Public Sub Arbitrary_quintuple_byte()
         Dim integers = {&HFF000000UI}
         Dim expected = {&H8FUI, &HF8UI, &H80UI, &H80UI, &H0UI}
+        Dim result as IEnumerable(Of UInteger) = Encode(integers)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Asymmetric_quintuple_byte()
+        Dim integers = {&H86656105UI}
+        Dim expected = {&H88UI, &HB3UI, &H95UI, &HC2UI, &H5UI}
         Dim result as IEnumerable(Of UInteger) = Encode(integers)
         Assert.Equal(expected, result)
     End Sub


### PR DESCRIPTION
## Description
Syncs the `variable-length-quantity` exercise tests with the latest canonical data from `problem-specifications`.

### Changes

- Added 5 missing canonical asymmetric encode test cases.
- Updated `.meta/tests.toml` using `configlet sync`.
- Verified the complete test suite.

### Verification

```text
Test summary: total: 31, failed: 0, succeeded: 31, skipped: 0
```

Refs #510