### PR TITLE
Sync anagram tests with problem specifications

### DIFF
--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -13,6 +13,7 @@ description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+include = false
 
 [03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
 description = "detects two anagrams"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -44,12 +44,41 @@ description = "detects anagrams using case-insensitive possible matches"
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
+include = false
+
+[630abb71-a94e-4715-8395-179ec1df9f91]
+description = "does not detect an anagram if the original word is repeated"
+reimplements = "7cc195ad-e3c7-44ee-9fd2-d3c344806a2c"
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
+include = false
+
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"
+
+[a6854f66-eec1-4afd-a137-62ef2870c051]
+description = "handles case of greek letters"
+
+[fd3509e5-e3ba-409d-ac3d-a9ac84d13296]
+description = "different characters may have the same bytes"

--- a/exercises/practice/anagram/AnagramTests.vb
+++ b/exercises/practice/anagram/AnagramTests.vb
@@ -36,6 +36,42 @@ Public Class AnagramTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub OriginalWordRepeated()
+        Dim detector = New Anagram("go")
+        Dim words = {"goGoGO"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub BananaIsNotAnagramOfItself()
+        Dim detector = New Anagram("BANANA")
+        Dim words = {"BANANA"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub BananaDifferentCaseIsNotAnagram()
+        Dim detector = New Anagram("BANANA")
+        Dim words = {"Banana"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub BananaCompletelyDifferentCaseIsNotAnagram()
+        Dim detector = New Anagram("BANANA")
+        Dim words = {"banana"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub IdenticalWordIsNotAnagram()
         Dim detector = New Anagram("corn")
         Dim words = {"corn", "dark", "Corn", "rank", "CORN", "cron",
@@ -77,6 +113,33 @@ Public Class AnagramTest
         Dim detector = New Anagram("Orchestra")
         Dim words = {"cashregister", "Carthorse", "radishes"}
         Dim expected = {"Carthorse"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub ListenHasSilentAsAnagram()
+        Dim detector = New Anagram("LISTEN")
+        Dim words = {"LISTEN", "Silent"}
+        Dim expected = {"Silent"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub GreekLettersAreHandledCaseInsensitively()
+        Dim detector = New Anagram("ΑΒΓ")
+        Dim words = {"ΒΓΑ", "ΒΓΔ", "γβα", "αβγ"}
+        Dim expected = {"ΒΓΑ", "γβα"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub DifferentCharactersWithSameBytesAreNotAnagrams()
+        Dim detector = New Anagram("a⬂")
+        Dim words = {"€a"}
+        Dim expected = Array.Empty(Of String)()
         Dim result as IEnumerable(Of String) = detector.Match(words)
         Assert.Equal(expected, result)
     End Sub

--- a/exercises/practice/anagram/AnagramTests.vb
+++ b/exercises/practice/anagram/AnagramTests.vb
@@ -17,11 +17,11 @@ Public Class AnagramTest
         Assert.Equal(expected, result)
     End Sub
 
-    <Fact(Skip:="Remove this Skip property to run this test")>
+    <Fact>
     Public Sub DetectMultipleAnagrams()
-        Dim detector = New Anagram("master")
-        Dim words = {"stream", "pigeon", "maters"}
-        Dim expected = {"maters", "stream"}
+        Dim detector = New Anagram("solemn")
+        Dim words = {"lemons", "cherry", "melons"}
+        Dim expected = {"lemons", "melons"}
         Dim result as IEnumerable(Of String) = detector.Match(words)
         Assert.Equal(expected, result)
     End Sub

--- a/exercises/practice/anagram/AnagramTests.vb
+++ b/exercises/practice/anagram/AnagramTests.vb
@@ -9,15 +9,6 @@ Public Class AnagramTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub DetectSimpleAnagram()
-        Dim detector = New Anagram("ant")
-        Dim words = {"tan", "stand", "at"}
-        Dim expected = {"tan"}
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact>
     Public Sub DetectMultipleAnagrams()
         Dim detector = New Anagram("solemn")
         Dim words = {"lemons", "cherry", "melons"}
@@ -27,10 +18,37 @@ Public Class AnagramTest
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub DoesNotConfuseDifferentDuplicates()
-        Dim detector = New Anagram("galea")
-        Dim words = {"eagle"}
+    Public Sub EliminateAnagramSubsets()
+        Dim detector = New Anagram("good")
+        Dim words = {"dog", "goody"}
         Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub DetectAnagrams()
+        Dim detector = New Anagram("allergy")
+        Dim words = {"gallery", "ballerina", "regally", "clergy", "largely", "leading"}
+        Dim expected = {"gallery", "largely", "regally"}
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub EliminateAnagramsWithSameChecksum()
+        Dim detector = New Anagram("mass")
+        Dim words = {"last"}
+        Dim expected = Array.Empty(Of String)()
+        Dim result as IEnumerable(Of String) = detector.Match(words)
+        Assert.Equal(expected, result)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub AnagramsAreCaseInsensitive()
+        Dim detector = New Anagram("Orchestra")
+        Dim words = {"cashregister", "Carthorse", "radishes"}
+        Dim expected = {"Carthorse"}
         Dim result as IEnumerable(Of String) = detector.Match(words)
         Assert.Equal(expected, result)
     End Sub
@@ -67,52 +85,6 @@ Public Class AnagramTest
         Dim detector = New Anagram("BANANA")
         Dim words = {"banana"}
         Dim expected = Array.Empty(Of String)()
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub IdenticalWordIsNotAnagram()
-        Dim detector = New Anagram("corn")
-        Dim words = {"corn", "dark", "Corn", "rank", "CORN", "cron",
-            "park"}
-        Dim expected = {"cron"}
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub EliminateAnagramsWithSameChecksum()
-        Dim detector = New Anagram("mass")
-        Dim words = {"last"}
-        Dim expected = Array.Empty(Of String)()
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub EliminateAnagramSubsets()
-        Dim detector = New Anagram("good")
-        Dim words = {"dog", "goody"}
-        Dim expected = Array.Empty(Of String)()
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub DetectAnagrams()
-        Dim detector = New Anagram("allergy")
-        Dim words = {"gallery", "ballerina", "regally", "clergy", "largely", "leading"}
-        Dim expected = {"gallery", "largely", "regally"}
-        Dim result as IEnumerable(Of String) = detector.Match(words)
-        Assert.Equal(expected, result)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub AnagramsAreCaseInsensitive()
-        Dim detector = New Anagram("Orchestra")
-        Dim words = {"cashregister", "Carthorse", "radishes"}
-        Dim expected = {"Carthorse"}
         Dim result as IEnumerable(Of String) = detector.Match(words)
         Assert.Equal(expected, result)
     End Sub


### PR DESCRIPTION
## Description

Syncs the `anagram` exercise with the latest canonical test cases from the `problem-specifications` repository.

### Changes

- Added the new canonical test cases for repeated words and case variations.
- Added the new `LISTEN` anagram case.
- Added the Greek-letter case.
- Added the Unicode character/byte collision case.
- Updated `.meta/tests.toml` with the new canonical UUIDs and `reimplements` relationships.
- Marked replaced canonical cases with `include = false`.

### Verification

- `git diff --check` passes.
- `pwsh ./bin/test.ps1 anagram` passes with **16/16 tests**.

Closes #420