### PR TITLE
Sync armstrong-numbers tests with problem specifications

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -38,6 +38,10 @@ description = "Seven-digit number that is not an Armstrong number"
 
 [5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
 description = "Armstrong number containing seven zeroes"
+include = false
+comment = "Omitted because the test input exceeds the range of the exercise's Integer parameter"
 
 [12ffbf10-307a-434e-b4ad-c925680e1dd4]
 description = "The largest and last Armstrong number"
+include = false
+comment = "Omitted because the test input exceeds the range of the exercise's Integer parameter"


### PR DESCRIPTION
Syncs the `armstrong-numbers` exercise with the latest canonical test data from `problem-specifications`.

### Changes

- Verified the existing test suite against the canonical data.
- Added intentional exclusions for the two canonical `big-integer` cases that exceed the range of the exercise's `Integer` parameter.
- Documented the reason for both exclusions in `.meta/tests.toml`.

### Verification

- `pwsh ./bin/test.ps1 armstrong-numbers`
- All 9 supported tests pass successfully.

Closes #421