### PR TITLE
Sync dnd-character tests with problem specifications

### DIFF
--- a/exercises/practice/dnd-character/.meta/tests.toml
+++ b/exercises/practice/dnd-character/.meta/tests.toml
@@ -10,52 +10,52 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [1e9ae1dc-35bd-43ba-aa08-e4b94c20fa37]
-description = "ability modifier for score 3 is -4"
+description = "ability modifier -> ability modifier for score 3 is -4"
 
 [cc9bb24e-56b8-4e9e-989d-a0d1a29ebb9c]
-description = "ability modifier for score 4 is -3"
+description = "ability modifier -> ability modifier for score 4 is -3"
 
 [5b519fcd-6946-41ee-91fe-34b4f9808326]
-description = "ability modifier for score 5 is -3"
+description = "ability modifier -> ability modifier for score 5 is -3"
 
 [dc2913bd-6d7a-402e-b1e2-6d568b1cbe21]
-description = "ability modifier for score 6 is -2"
+description = "ability modifier -> ability modifier for score 6 is -2"
 
 [099440f5-0d66-4b1a-8a10-8f3a03cc499f]
-description = "ability modifier for score 7 is -2"
+description = "ability modifier -> ability modifier for score 7 is -2"
 
 [cfda6e5c-3489-42f0-b22b-4acb47084df0]
-description = "ability modifier for score 8 is -1"
+description = "ability modifier -> ability modifier for score 8 is -1"
 
 [c70f0507-fa7e-4228-8463-858bfbba1754]
-description = "ability modifier for score 9 is -1"
+description = "ability modifier -> ability modifier for score 9 is -1"
 
 [6f4e6c88-1cd9-46a0-92b8-db4a99b372f7]
-description = "ability modifier for score 10 is 0"
+description = "ability modifier -> ability modifier for score 10 is 0"
 
 [e00d9e5c-63c8-413f-879d-cd9be9697097]
-description = "ability modifier for score 11 is 0"
+description = "ability modifier -> ability modifier for score 11 is 0"
 
 [eea06f3c-8de0-45e7-9d9d-b8cab4179715]
-description = "ability modifier for score 12 is +1"
+description = "ability modifier -> ability modifier for score 12 is +1"
 
 [9c51f6be-db72-4af7-92ac-b293a02c0dcd]
-description = "ability modifier for score 13 is +1"
+description = "ability modifier -> ability modifier for score 13 is +1"
 
 [94053a5d-53b6-4efc-b669-a8b5098f7762]
-description = "ability modifier for score 14 is +2"
+description = "ability modifier -> ability modifier for score 14 is +2"
 
 [8c33e7ca-3f9f-4820-8ab3-65f2c9e2f0e2]
-description = "ability modifier for score 15 is +2"
+description = "ability modifier -> ability modifier for score 15 is +2"
 
 [c3ec871e-1791-44d0-b3cc-77e5fb4cd33d]
-description = "ability modifier for score 16 is +3"
+description = "ability modifier -> ability modifier for score 16 is +3"
 
 [3d053cee-2888-4616-b9fd-602a3b1efff4]
-description = "ability modifier for score 17 is +3"
+description = "ability modifier -> ability modifier for score 17 is +3"
 
 [bafd997a-e852-4e56-9f65-14b60261faee]
-description = "ability modifier for score 18 is +4"
+description = "ability modifier -> ability modifier for score 18 is +4"
 
 [4f28f19c-2e47-4453-a46a-c0d365259c14]
 description = "random ability is within range"
@@ -65,3 +65,8 @@ description = "random character is valid"
 
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
+include = false
+
+[dca2b2ec-f729-4551-84b9-078876bb4808]
+description = "each ability is only calculated once"
+reimplements = "2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe"


### PR DESCRIPTION
Updated the `dnd-character` test metadata to match the latest canonical data from `problem-specifications`.

- Updated the canonical descriptions for the ability modifier cases.
- Replaced the outdated `each ability is only calculated once` case with its new canonical implementation.
- No changes were required to `DndCharacterTests.vb` or `.meta/Example.vb`.

## Verification

- `20/20` tests passing
- `configlet sync` reports the exercise as up to date
- `git diff --cached --check` passes cleanly

Closes #438