### PR TITLE
Sync poker with problem specifications

### DIFF
--- a/exercises/practice/poker/.meta/tests.toml
+++ b/exercises/practice/poker/.meta/tests.toml
@@ -21,11 +21,17 @@ description = "a tie has multiple winners"
 [61ed83a9-cfaa-40a5-942a-51f52f0a8725]
 description = "multiple hands with the same high cards, tie compares next highest ranked, down to last card"
 
+[da01becd-f5b0-4342-b7f3-1318191d0580]
+description = "winning high card hand also has the lowest card"
+
 [f7175a89-34ff-44de-b3d7-f6fd97d1fca4]
 description = "one pair beats high card"
 
 [e114fd41-a301-4111-a9e7-5a7f72a76561]
 description = "highest pair wins"
+
+[b3acd3a7-f9fa-4647-85ab-e0a9e07d1365]
+description = "both hands have the same pair, high card wins"
 
 [935bb4dc-a622-4400-97fa-86e7d06b1f76]
 description = "two pairs beats one pair"
@@ -53,6 +59,11 @@ description = "both hands have three of a kind, tie goes to highest ranked tripl
 
 [eb856cc2-481c-4b0d-9835-4d75d07a5d9d]
 description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
+include = false
+
+[26a4a7d4-34a2-4f18-90b4-4a8dd35d2bb1]
+description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
+reimplements = "eb856cc2-481c-4b0d-9835-4d75d07a5d9d"
 
 [a858c5d9-2f28-48e7-9980-b7fa04060a60]
 description = "a straight beats three of a kind"
@@ -62,6 +73,9 @@ description = "aces can end a straight (10 J Q K A)"
 
 [76856b0d-35cd-49ce-a492-fe5db53abc02]
 description = "aces can start a straight (A 2 3 4 5)"
+
+[e214b7df-dcba-45d3-a2e5-342d8c46c286]
+description = "aces cannot be in the middle of a straight (Q K A 2 3)"
 
 [6980c612-bbff-4914-b17a-b044e4e69ea1]
 description = "both hands with a straight, tie goes to highest ranked card"
@@ -74,6 +88,11 @@ description = "flush beats a straight"
 
 [4d90261d-251c-49bd-a468-896bf10133de]
 description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
+include = false
+
+[e04137c5-c19a-4dfc-97a1-9dfe9baaa2ff]
+description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
+reimplements = "4d90261d-251c-49bd-a468-896bf10133de"
 
 [3a19361d-8974-455c-82e5-f7152f5dba7c]
 description = "full house beats a flush"
@@ -96,5 +115,17 @@ description = "with multiple decks, both hands with identical four of a kind, ti
 [923bd910-dc7b-4f7d-a330-8b42ec10a3ac]
 description = "straight flush beats four of a kind"
 
+[d9629e22-c943-460b-a951-2134d1b43346]
+description = "aces can end a straight flush (10 J Q K A)"
+
+[05d5ede9-64a5-4678-b8ae-cf4c595dc824]
+description = "aces can start a straight flush (A 2 3 4 5)"
+
+[ad655466-6d04-49e8-a50c-0043c3ac18ff]
+description = "aces cannot be in the middle of a straight flush (Q K A 2 3)"
+
 [d0927f70-5aec-43db-aed8-1cbd1b6ee9ad]
-description = "both hands have straight flush, tie goes to highest-ranked card"
+description = "both hands have a straight flush, tie goes to highest-ranked card"
+
+[be620e09-0397-497b-ac37-d1d7a4464cfc]
+description = "even though an ace is usually high, a 5-high straight flush is the lowest-scoring straight flush"

--- a/exercises/practice/poker/PokerTests.vb
+++ b/exercises/practice/poker/PokerTests.vb
@@ -128,14 +128,6 @@ Public Class PokerTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub With_multiple_decks_two_players_can_have_same_three_of_a_kind_ties_go_to_highest_remaining_cards()
-        Dim hands = {"4S AH AS 7C AD", "4S AH AS 8C AD"}
-        Dim actual = BestHands(hands)
-        Dim expected = {"4S AH AS 8C AD"}
-        Assert.Equal(expected, actual)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub A_straight_beats_three_of_a_kind()
         Dim hands = {"4S 5H 4C 8D 4H", "3S 4D 2S 6D 5C"}
         Dim actual = BestHands(hands)
@@ -188,22 +180,6 @@ Public Class PokerTests
         Dim hands = {"4C 6H 7D 8D 5H", "2S 4S 5S 6S 7S"}
         Dim actual = BestHands(hands)
         Dim expected = {"2S 4S 5S 6S 7S"}
-        Assert.Equal(expected, actual)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Both_hands_have_a_flush_tie_goes_to_high_card_down_to_the_last_one_if_necessary()
-        Dim hands = {"4H 7H 8H 9H 6H", "2S 4S 5S 6S 7S"}
-        Dim actual = BestHands(hands)
-        Dim expected = {"4H 7H 8H 9H 6H"}
-        Assert.Equal(expected, actual)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Full_house_beats_a_flush()
-        Dim hands = {"3H 6H 7H 8H 5H", "4S 5H 4C 5D 4H"}
-        Dim actual = BestHands(hands)
-        Dim expected = {"4S 5H 4C 5D 4H"}
         Assert.Equal(expected, actual)
     End Sub
 
@@ -280,18 +256,18 @@ Public Class PokerTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Even_though_an_ace_is_usually_high_a_5_high_straight_flush_is_the_lowest_scoring_straight_flush()
-        Dim hands = {"2H 3H 4H 5H 6H", "4D AD 3D 2D 5D"}
-        Dim actual = BestHands(hands)
-        Dim expected = {"2H 3H 4H 5H 6H"}
-        Assert.Equal(expected, actual)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Both_hands_have_a_straight_flush_tie_goes_to_highest_ranked_card()
         Dim hands = {"4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"}
         Dim actual = BestHands(hands)
         Dim expected = {"5S 7S 8S 9S 6S"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Even_though_an_ace_is_usually_high_a_5_high_straight_flush_is_the_lowest_scoring_straight_flush()
+        Dim hands = {"2H 3H 4H 5H 6H", "4D AD 3D 2D 5D"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"2H 3H 4H 5H 6H"}
         Assert.Equal(expected, actual)
     End Sub
 End Class

--- a/exercises/practice/poker/PokerTests.vb
+++ b/exercises/practice/poker/PokerTests.vb
@@ -32,6 +32,14 @@ Public Class PokerTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Winning_high_card_hand_also_has_the_lowest_card()
+        Dim hands = {"2S 5H 6S 8D 7H", "3S 4D 6D 8C 7S"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"2S 5H 6S 8D 7H"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub One_pair_beats_high_card()
         Dim hands = {"4S 5H 6C 8D KH", "2S 4H 6S 4D JH"}
         Dim actual = BestHands(hands)
@@ -44,6 +52,14 @@ Public Class PokerTests
         Dim hands = {"4S 2H 6S 2D JH", "2S 4H 6C 4D JD"}
         Dim actual = BestHands(hands)
         Dim expected = {"2S 4H 6C 4D JD"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Both_hands_have_the_same_pair_high_card_wins()
+        Dim hands = {"4H 4S AH JC 3D", "4C 4D AS 5D 6C"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"4H 4S AH JC 3D"}
         Assert.Equal(expected, actual)
     End Sub
 
@@ -144,6 +160,14 @@ Public Class PokerTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Aces_cannot_be_in_the_middle_of_a_straight_Q_K_A_2_3()
+        Dim hands = {"2C 3D 7H 5H 2S", "QS KH AC 2D 3S"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"2C 3D 7H 5H 2S"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Both_hands_with_a_straight_tie_goes_to_highest_ranked_card()
         Dim hands = {"4S 6C 7S 8D 5H", "5S 7H 8S 9D 6H"}
         Dim actual = BestHands(hands)
@@ -228,6 +252,38 @@ Public Class PokerTests
         Dim hands = {"4S 5H 5S 5D 5C", "7S 8S 9S 6S 10S"}
         Dim actual = BestHands(hands)
         Dim expected = {"7S 8S 9S 6S 10S"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Aces_can_end_a_straight_flush_10_J_Q_K_A()
+        Dim hands = {"KC AH AS AD AC", "10C JC QC KC AC"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"10C JC QC KC AC"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Aces_can_start_a_straight_flush_A_2_3_4_5()
+        Dim hands = {"KS AH AS AD AC", "4H AH 3H 2H 5H"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"4H AH 3H 2H 5H"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Aces_cannot_be_in_the_middle_of_a_straight_flush_Q_K_A_2_3()
+        Dim hands = {"2C AC QC 10C KC", "QH KH AH 2H 3H"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"2C AC QC 10C KC"}
+        Assert.Equal(expected, actual)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Even_though_an_ace_is_usually_high_a_5_high_straight_flush_is_the_lowest_scoring_straight_flush()
+        Dim hands = {"2H 3H 4H 5H 6H", "4D AD 3D 2D 5D"}
+        Dim actual = BestHands(hands)
+        Dim expected = {"2H 3H 4H 5H 6H"}
         Assert.Equal(expected, actual)
     End Sub
 


### PR DESCRIPTION
Sync the Poker exercise with the latest canonical test data from `problem-specifications`.

#### Changes

- Added 7 missing canonical test cases to `PokerTests.vb`
- Updated `.meta/tests.toml` with the corresponding canonical test entries
- Applied the canonical `reimplements` relationships, excluding replaced cases
- Updated the affected canonical test description

No changes to `Example.vb` were required.

#### Verification

- `./bin/configlet sync -e poker --tests`
- `pwsh ./bin/test.ps1 poker`
- Result: **37/37 tests passing**

Closes #472 