### PR TITLE
Sync linked-list with problem specifications

### DIFF
--- a/exercises/practice/linked-list/.meta/Example.vb
+++ b/exercises/practice/linked-list/.meta/Example.vb
@@ -1,51 +1,103 @@
 Public Class Deque(Of T)
     Private head As Element
+    Private tail As Element
+    Private itemCount As Integer
+
+    Public ReadOnly Property Count As Integer
+        Get
+            Return itemCount
+        End Get
+    End Property
 
     Public Sub Push(ByVal value As T)
-        If head Is Nothing Then
-            head = New Element(value)
+        Dim element = New Element(value)
+
+        If tail Is Nothing Then
+            head = element
+            tail = element
         Else
-            Dim last = head.Next
-            Dim e = New Element(value, last, head)
-            last.Prev = e
-            head.Next = e
+            element.Prev = tail
+            tail.[Next] = element
+            tail = element
         End If
+
+        itemCount += 1
     End Sub
 
     Public Function Pop() As T
-        head = head.Next
-        Return Shift()
+        Dim value = tail.Value
+
+        If tail Is head Then
+            head = Nothing
+            tail = Nothing
+        Else
+            tail = tail.Prev
+            tail.[Next] = Nothing
+        End If
+
+        itemCount -= 1
+        Return value
     End Function
 
     Public Sub Unshift(ByVal value As T)
-        Push(value)
-        head = head.Next
+        Dim element = New Element(value)
+
+        If head Is Nothing Then
+            head = element
+            tail = element
+        Else
+            element.[Next] = head
+            head.Prev = element
+            head = element
+        End If
+
+        itemCount += 1
     End Sub
 
     Public Function Shift() As T
         Dim value = head.Value
-        Dim last = head.Next
 
-        If last Is head Then
+        If head Is tail Then
             head = Nothing
+            tail = Nothing
         Else
-            last.Prev = head.Prev
-            head.Prev.Next = last
-            head = head.Prev
+            head = head.[Next]
+            head.Prev = Nothing
         End If
 
+        itemCount -= 1
         Return value
     End Function
 
+    Public Sub Delete(ByVal value As T)
+        Dim current = head
+
+        While current IsNot Nothing
+            If EqualityComparer(Of T).Default.Equals(current.Value, value) Then
+                If current Is head Then
+                    Shift()
+                ElseIf current Is tail Then
+                    Pop()
+                Else
+                    current.Prev.[Next] = current.[Next]
+                    current.[Next].Prev = current.Prev
+                    itemCount -= 1
+                End If
+
+                Return
+            End If
+
+            current = current.[Next]
+        End While
+    End Sub
+
     Private Class Element
         Public ReadOnly Value As T
-        Public [Next] As Element
-        Public Prev As Element
+        Public Property [Next] As Element
+        Public Property Prev As Element
 
-        Public Sub New(ByVal value As T, ByVal Optional [next] As Element = Nothing, ByVal Optional prev As Element = Nothing)
+        Public Sub New(ByVal value As T)
             Me.Value = value
-            Me.Next = If([next], Me)
-            Me.Prev = If(prev, Me)
         End Sub
     End Class
 End Class

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,6 +1,7 @@
 {
   "authors": [
-    "ErikSchierboom"
+    "ErikSchierboom",
+    "ManasDasri"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/linked-list/LinkedList.vb
+++ b/exercises/practice/linked-list/LinkedList.vb
@@ -1,17 +1,26 @@
 Public Class Deque(Of T)
-    Public Sub PushMethod(ByVal value As T)
+    Public Sub Push(ByVal value As T)
         Throw New NotImplementedException("You need to implement this function.")
     End Sub
-
     Public Function Pop() As T
         Throw New NotImplementedException("You need to implement this function.")
     End Function
 
-    Public Sub UnshiftMethod(ByVal value As T)
+    Public Sub Unshift(ByVal value As T)
         Throw New NotImplementedException("You need to implement this function.")
     End Sub
 
     Public Function Shift() As T
+        Throw New NotImplementedException("You need to implement this function.")
+    End Function
+
+    Public ReadOnly Property Count As Integer
+        Get
+            Throw New NotImplementedException("You need to implement this function.")
+        End Get
+    End Property
+
+    Public Sub Delete(ByVal value As T)
         Throw New NotImplementedException("You need to implement this function.")
     End Sub
 End Class

--- a/exercises/practice/linked-list/LinkedList.vb
+++ b/exercises/practice/linked-list/LinkedList.vb
@@ -1,103 +1,17 @@
 Public Class Deque(Of T)
-    Private head As Element
-    Private tail As Element
-    Private itemCount As Integer
-
-    Public ReadOnly Property Count As Integer
-        Get
-            Return itemCount
-        End Get
-    End Property
-
-    Public Sub Push(ByVal value As T)
-        Dim element = New Element(value)
-
-        If tail Is Nothing Then
-            head = element
-            tail = element
-        Else
-            element.Prev = tail
-            tail.[Next] = element
-            tail = element
-        End If
-
-        itemCount += 1
+    Public Sub PushMethod(ByVal value As T)
+        Throw New NotImplementedException("You need to implement this function.")
     End Sub
 
     Public Function Pop() As T
-        Dim value = tail.Value
-
-        If tail Is head Then
-            head = Nothing
-            tail = Nothing
-        Else
-            tail = tail.Prev
-            tail.[Next] = Nothing
-        End If
-
-        itemCount -= 1
-        Return value
+        Throw New NotImplementedException("You need to implement this function.")
     End Function
 
-    Public Sub Unshift(ByVal value As T)
-        Dim element = New Element(value)
-
-        If head Is Nothing Then
-            head = element
-            tail = element
-        Else
-            element.[Next] = head
-            head.Prev = element
-            head = element
-        End If
-
-        itemCount += 1
+    Public Sub UnshiftMethod(ByVal value As T)
+        Throw New NotImplementedException("You need to implement this function.")
     End Sub
 
     Public Function Shift() As T
-        Dim value = head.Value
-
-        If head Is tail Then
-            head = Nothing
-            tail = Nothing
-        Else
-            head = head.[Next]
-            head.Prev = Nothing
-        End If
-
-        itemCount -= 1
-        Return value
-    End Function
-
-    Public Sub Delete(ByVal value As T)
-        Dim current = head
-
-        While current IsNot Nothing
-            If EqualityComparer(Of T).Default.Equals(current.Value, value) Then
-                If current Is head Then
-                    Shift()
-                ElseIf current Is tail Then
-                    Pop()
-                Else
-                    current.Prev.[Next] = current.[Next]
-                    current.[Next].Prev = current.Prev
-                    itemCount -= 1
-                End If
-
-                Return
-            End If
-
-            current = current.[Next]
-        End While
+        Throw New NotImplementedException("You need to implement this function.")
     End Sub
-
-    Private Class Element
-        Public ReadOnly Value As T
-        Public Property [Next] As Element
-        Public Property Prev As Element
-
-        Public Sub New(ByVal value As T)
-            Me.Value = value
-        End Sub
-    End Class
 End Class

--- a/exercises/practice/linked-list/LinkedList.vb
+++ b/exercises/practice/linked-list/LinkedList.vb
@@ -1,17 +1,103 @@
 Public Class Deque(Of T)
-    Public Sub PushMethod(ByVal value As T)
-        Throw New NotImplementedException("You need to implement this function.")
+    Private head As Element
+    Private tail As Element
+    Private itemCount As Integer
+
+    Public ReadOnly Property Count As Integer
+        Get
+            Return itemCount
+        End Get
+    End Property
+
+    Public Sub Push(ByVal value As T)
+        Dim element = New Element(value)
+
+        If tail Is Nothing Then
+            head = element
+            tail = element
+        Else
+            element.Prev = tail
+            tail.[Next] = element
+            tail = element
+        End If
+
+        itemCount += 1
     End Sub
 
     Public Function Pop() As T
-        Throw New NotImplementedException("You need to implement this function.")
+        Dim value = tail.Value
+
+        If tail Is head Then
+            head = Nothing
+            tail = Nothing
+        Else
+            tail = tail.Prev
+            tail.[Next] = Nothing
+        End If
+
+        itemCount -= 1
+        Return value
     End Function
 
-    Public Sub UnshiftMethod(ByVal value As T)
-        Throw New NotImplementedException("You need to implement this function.")
+    Public Sub Unshift(ByVal value As T)
+        Dim element = New Element(value)
+
+        If head Is Nothing Then
+            head = element
+            tail = element
+        Else
+            element.[Next] = head
+            head.Prev = element
+            head = element
+        End If
+
+        itemCount += 1
     End Sub
 
     Public Function Shift() As T
-        Throw New NotImplementedException("You need to implement this function.")
+        Dim value = head.Value
+
+        If head Is tail Then
+            head = Nothing
+            tail = Nothing
+        Else
+            head = head.[Next]
+            head.Prev = Nothing
+        End If
+
+        itemCount -= 1
+        Return value
     End Function
+
+    Public Sub Delete(ByVal value As T)
+        Dim current = head
+
+        While current IsNot Nothing
+            If EqualityComparer(Of T).Default.Equals(current.Value, value) Then
+                If current Is head Then
+                    Shift()
+                ElseIf current Is tail Then
+                    Pop()
+                Else
+                    current.Prev.[Next] = current.[Next]
+                    current.[Next].Prev = current.Prev
+                    itemCount -= 1
+                End If
+
+                Return
+            End If
+
+            current = current.[Next]
+        End While
+    End Sub
+
+    Private Class Element
+        Public ReadOnly Value As T
+        Public Property [Next] As Element
+        Public Property Prev As Element
+
+        Public Sub New(ByVal value As T)
+            Me.Value = value
+        End Sub
+    End Class
 End Class

--- a/exercises/practice/linked-list/LinkedListTests.vb
+++ b/exercises/practice/linked-list/LinkedListTests.vb
@@ -1,76 +1,194 @@
 Public Class DequeTests
     <Fact>
-    Public Sub Push_and_pop_are_first_in_last_out_order()
+    Public Sub Pop_gets_element_from_the_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Push(10)
-        deque.Push(20)
-        Assert.Equal(20, deque.Pop())
-        Assert.Equal(10, deque.Pop())
+        deque.Push(7)
+        Assert.Equal(7, deque.Pop())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Push_and_shift_are_first_in_first_out_order()
+    Public Sub Push_pop_respectively_add_remove_at_the_end_of_the_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Push(10)
-        deque.Push(20)
-        Assert.Equal(10, deque.Shift())
-        Assert.Equal(20, deque.Shift())
+        deque.Push(11)
+        deque.Push(13)
+        Assert.Equal(13, deque.Pop())
+        Assert.Equal(11, deque.Pop())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Unshift_and_shift_are_last_in_first_out_order()
+    Public Sub Shift_gets_an_element_from_the_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Unshift(10)
-        deque.Unshift(20)
-        Assert.Equal(20, deque.Shift())
-        Assert.Equal(10, deque.Shift())
+        deque.Push(17)
+        Assert.Equal(17, deque.Shift())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Unshift_and_pop_are_last_in_last_out_order()
+    Public Sub Shift_gets_first_element_from_the_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Unshift(10)
-        deque.Unshift(20)
-        Assert.Equal(10, deque.Pop())
-        Assert.Equal(20, deque.Pop())
+        deque.Push(23)
+        deque.Push(5)
+        Assert.Equal(23, deque.Shift())
+        Assert.Equal(5, deque.Shift())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Push_and_pop_can_handle_multiple_values()
+    Public Sub Unshift_adds_element_at_start_of_the_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Push(10)
-        deque.Push(20)
-        deque.Push(30)
-        Assert.Equal(30, deque.Pop())
-        Assert.Equal(20, deque.Pop())
-        Assert.Equal(10, deque.Pop())
+        deque.Unshift(23)
+        deque.Unshift(5)
+        Assert.Equal(5, deque.Shift())
+        Assert.Equal(23, deque.Shift())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Unshift_and_shift_can_handle_multiple_values()
+    Public Sub Pop_push_shift_and_unshift_can_be_used_in_any_order()
         Dim deque = New Deque(Of Integer)()
-        deque.Unshift(10)
-        deque.Unshift(20)
-        deque.Unshift(30)
-        Assert.Equal(30, deque.Shift())
-        Assert.Equal(20, deque.Shift())
-        Assert.Equal(10, deque.Shift())
+        deque.Push(1)
+        deque.Push(2)
+        Assert.Equal(2, deque.Pop())
+        deque.Push(3)
+        Assert.Equal(1, deque.Shift())
+        deque.Unshift(4)
+        deque.Push(5)
+        Assert.Equal(4, deque.Shift())
+        Assert.Equal(5, deque.Pop())
+        Assert.Equal(3, deque.Shift())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub All_methods_of_manipulating_the_deque_can_be_used_together()
+    Public Sub Count_an_empty_list()
         Dim deque = New Deque(Of Integer)()
-        deque.Push(10)
-        deque.Push(20)
-        Assert.Equal(20, deque.Pop())
+        Assert.Equal(0, deque.Count)
+    End Sub
 
-        deque.Push(30)
-        Assert.Equal(10, deque.Shift())
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Count_a_list_with_items()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(37)
+        deque.Push(1)
+        Assert.Equal(2, deque.Count)
+    End Sub
 
-        deque.Unshift(40)
-        deque.Push(50)
-        Assert.Equal(40, deque.Shift())
-        Assert.Equal(50, deque.Pop())
-        Assert.Equal(30, deque.Shift())
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Count_is_correct_after_mutation()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(31)
+        Assert.Equal(1, deque.Count)
+        deque.Unshift(43)
+        Assert.Equal(2, deque.Count)
+        deque.Shift()
+        Assert.Equal(1, deque.Count)
+        deque.Pop()
+        Assert.Equal(0, deque.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Popping_to_empty_does_not_break_the_list()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(41)
+        deque.Push(59)
+        deque.Pop()
+        deque.Pop()
+        deque.Push(47)
+        Assert.Equal(1, deque.Count)
+        Assert.Equal(47, deque.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Shifting_to_empty_does_not_break_the_list()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(41)
+        deque.Push(59)
+        deque.Shift()
+        deque.Shift()
+        deque.Push(47)
+        Assert.Equal(1, deque.Count)
+        Assert.Equal(47, deque.Shift())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_only_element()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(61)
+        deque.Delete(61)
+        Assert.Equal(0, deque.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_element_with_the_specified_value_from_the_list()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(71)
+        deque.Push(83)
+        deque.Push(79)
+        deque.Delete(83)
+        Assert.Equal(2, deque.Count)
+        Assert.Equal(79, deque.Pop())
+        Assert.Equal(71, deque.Shift())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(71)
+        deque.Push(83)
+        deque.Push(79)
+        deque.Delete(83)
+        Assert.Equal(2, deque.Count)
+        Assert.Equal(79, deque.Pop())
+        Assert.Equal(71, deque.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_element_with_the_specified_value_from_the_list_reassigns_head()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(71)
+        deque.Push(83)
+        deque.Push(79)
+        deque.Delete(83)
+        Assert.Equal(2, deque.Count)
+        Assert.Equal(71, deque.Shift())
+        Assert.Equal(79, deque.Shift())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_first_of_two_elements()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(97)
+        deque.Push(101)
+        deque.Delete(97)
+        Assert.Equal(1, deque.Count)
+        Assert.Equal(101, deque.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_the_second_of_two_elements()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(97)
+        deque.Push(101)
+        deque.Delete(101)
+        Assert.Equal(1, deque.Count)
+        Assert.Equal(97, deque.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Delete_does_not_modify_the_list_if_the_element_is_not_found()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(89)
+        deque.Delete(103)
+        Assert.Equal(1, deque.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Deletes_only_the_first_occurrence()
+        Dim deque = New Deque(Of Integer)()
+        deque.Push(73)
+        deque.Push(9)
+        deque.Push(9)
+        deque.Push(107)
+        deque.Delete(9)
+        Assert.Equal(3, deque.Count)
+        Assert.Equal(107, deque.Pop())
+        Assert.Equal(9, deque.Pop())
+        Assert.Equal(73, deque.Pop())
     End Sub
 End Class


### PR DESCRIPTION
Sync the Linked List exercise with the latest canonical test data from `problem-specifications`.

#### Changes
- Rebuilt the exercise API to match the canonical specification
- Added support for `Push`, `Pop`, `Shift`, `Unshift`, `Count`, and `Delete`
- Replaced the existing track-specific tests with all 19 canonical test cases
- Updated `.meta/Example.vb` to implement the canonical API
- Added myself as an author in the exercise configuration

#### Verification
- `./bin/configlet sync -e linked-list --tests`
- `pwsh ./bin/test.ps1 linked-list`
- Result: **19/19 tests passing**
- `git diff --check` passes

Closes #458
