### PR TITLE
Sync two-bucket with problem specifications

### DIFF
--- a/exercises/practice/two-bucket/.meta/Example.vb
+++ b/exercises/practice/two-bucket/.meta/Example.vb
@@ -74,9 +74,9 @@ Public Class TwoBucket
 
     Public Function Measure(goal As Integer) As TwoBucketResult
         If goal > Math.Max(start.Size, other.Size) Then Throw New ArgumentException(goal)
-    
+
         If other.Size = goal Then Return New TwoBucketResult(2, other.Name, start.Size)
-    
+
         Dim moves = 0
 
         While start.Level <> goal AndAlso other.Level <> goal
@@ -87,17 +87,17 @@ Public Class TwoBucket
             Else
                 start.PourInto(other)
             End If
-    
+
             If start.IsFull AndAlso other.IsFull Then Throw New ArgumentException(goal)
-    
+
             moves += 1
         End While
-    
+
         If start.Level = goal Then
             Return New TwoBucketResult(moves, start.Name, other.Level)
         Else
             Return New TwoBucketResult(moves, other.Name, start.Level)
         End If
-            
+
     End Function
 End Class

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -27,6 +27,12 @@ description = "Measure one step using bucket one of size 1 and bucket two of siz
 [eb329c63-5540-4735-b30b-97f7f4df0f84]
 description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
 
+[58d70152-bf2b-46bb-ad54-be58ebe94c03]
+description = "Measure using bucket one much bigger than bucket two"
+
+[9dbe6499-caa5-4a58-b5ce-c988d71b8981]
+description = "Measure using bucket one much smaller than bucket two"
+
 [449be72d-b10a-4f4b-a959-ca741e333b72]
 description = "Not possible to reach the goal"
 

--- a/exercises/practice/two-bucket/TwoBucketTests.vb
+++ b/exercises/practice/two-bucket/TwoBucketTests.vb
@@ -54,6 +54,24 @@ Public Class TwoBucketTests
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Measure_using_bucket_one_much_bigger_than_bucket_two()
+        Dim sut = New TwoBucket(5, 1, Bucket.One)
+        Dim actual = sut.Measure(2)
+        Assert.Equal(6, actual.Moves)
+        Assert.Equal(1, actual.OtherBucket)
+        Assert.Equal(Bucket.One, actual.GoalBucket)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Measure_using_bucket_one_much_smaller_than_bucket_two()
+        Dim sut = New TwoBucket(3, 15, Bucket.One)
+        Dim actual = sut.Measure(9)
+        Assert.Equal(6, actual.Moves)
+        Assert.Equal(0, actual.OtherBucket)
+        Assert.Equal(Bucket.Two, actual.GoalBucket)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
     Public Sub Not_possible_to_reach_the_goal()
         Dim sut = New TwoBucket(6, 15, Bucket.One)
         Assert.Throws(Of ArgumentException)(Function() sut.Measure(5))


### PR DESCRIPTION
#### Changes
- Added the 2 missing canonical test cases.
- Updated `.meta/tests.toml` with the corresponding canonical entries.
- Removed trailing whitespace from `.meta/Example.vb`.

#### Verification
- `pwsh ./bin/test.ps1 two-bucket` → **11/11 tests passing**
- `./bin/configlet sync -e two-bucket --tests` → exercise is up to date
- `git diff --check` → clean

Closes #509