### PR TITLE
Update `simple-linked-list` for new canonical tests

### DIFF
--- a/exercises/practice/simple-linked-list/.meta/Example.vb
+++ b/exercises/practice/simple-linked-list/.meta/Example.vb
@@ -1,16 +1,16 @@
 Public Class SimpleLinkedList(Of T)
-    Implements IEnumerable(Of T)
-
-    Private _CountProp As Integer = 0
     Private Class Node
-        Public Property Value As T
+        Public Sub New(ByVal value As T, ByVal nextNode As Node)
+            Me.Value = value
+            [Next] = nextNode
+        End Sub
+
+        Public ReadOnly Property Value As T
         Public Property [Next] As Node
     End Class
 
     Private head As Node
-
-    Public Sub New()
-    End Sub
+    Private countValue As Integer
 
     Public Sub New(ParamArray values As T())
         For Each value In values
@@ -18,43 +18,55 @@ Public Class SimpleLinkedList(Of T)
         Next
     End Sub
 
-    Public Property Count As Integer
+    Public ReadOnly Property Count As Integer
         Get
-            Return _CountProp
+            Return countValue
         End Get
-        Private Set(value As Integer)
-            _CountProp = value
-        End Set
     End Property
 
     Public Sub Push(ByVal value As T)
-        Dim node = New Node With {
-            .Value = value,
-            .[Next] = head
-        }
-        head = node
-        Count += 1
+        head = New Node(value, head)
+        countValue += 1
     End Sub
 
     Public Function Pop() As T
-        If head Is Nothing Then
-            Throw New InvalidOperationException("List is empty!")
-        End If
-        Dim value = head.Value
+        Dim value = Peek()
         head = head.Next
-        Count -= 1
+        countValue -= 1
         Return value
     End Function
 
-    Public Iterator Function GetEnumerator() As IEnumerator(Of T) Implements IEnumerable(Of T).GetEnumerator
-        Dim current = head
-        While current IsNot Nothing
-            Yield current.Value
-            current = current.Next
-        End While
+    Public Function Peek() As T
+        If head Is Nothing Then
+            Throw New InvalidOperationException("The list is empty.")
+        End If
+
+        Return head.Value
     End Function
 
-    Private Function GetEnumerator1() As IEnumerator Implements IEnumerable.GetEnumerator
-        Return GetEnumerator()
+    Public Function ToList() As List(Of T)
+        Dim values = New List(Of T)()
+        Dim current = head
+
+        While current IsNot Nothing
+            values.Add(current.Value)
+            current = current.Next
+        End While
+
+        Return values
     End Function
+
+    Public Sub Reverse()
+        Dim previous As Node = Nothing
+        Dim current = head
+
+        While current IsNot Nothing
+            Dim following = current.Next
+            current.Next = previous
+            previous = current
+            current = following
+        End While
+
+        head = previous
+    End Sub
 End Class

--- a/exercises/practice/simple-linked-list/.meta/Generator.tpl
+++ b/exercises/practice/simple-linked-list/.meta/Generator.tpl
@@ -1,0 +1,27 @@
+Public Class {{ testClass }}
+    {{- for test in tests }}
+    {{ test.factAttribute }}
+    Public Sub {{ test.shortTestMethod }}()
+        Dim list = New {{ testedClass }}(Of Integer)({{ test.input.initialValues | array.join ", " }})
+        {{- for operation in test.input.operations }}
+        {{- if operation.operation == "count" }}
+        Assert.Equal({{ operation.expected }}, list.Count)
+        {{- else if operation.operation == "push" }}
+        list.Push({{ operation.value }})
+        {{- else if operation.operation == "reverse" }}
+        list.Reverse()
+        {{- else if operation.operation == "toList" }}
+        {{- if (array.size operation.expected) == 0 }}
+        Assert.Empty(list.ToList())
+        {{- else }}
+        Assert.Equal({{ operation.expected | vb_integer_array_literal }}, list.ToList())
+        {{- end }}
+        {{- else if operation.expected.error }}
+        Assert.Throws(Of InvalidOperationException)(Function() list.{{ operation.operation | pascalize }}())
+        {{- else }}
+        Assert.Equal({{ operation.expected }}, list.{{ operation.operation | pascalize }}())
+        {{- end }}
+        {{- end }}
+    End Sub
+    {{ end -}}
+End Class

--- a/exercises/practice/simple-linked-list/.meta/tests.toml
+++ b/exercises/practice/simple-linked-list/.meta/tests.toml
@@ -1,0 +1,104 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[962d998c-c203-41e2-8fbd-85a7b98b79b9]
+description = "count -> Empty list has length of zero"
+
+[9760262e-d7e4-4639-9840-87e2e2fbb115]
+description = "count -> Singleton list has length of one"
+
+[d9955c90-637c-441b-b41d-8cfb48e924a8]
+description = "count -> Non-empty list has correct length"
+
+[0c3966db-58f9-4632-b94c-8ea13e54c2c8]
+description = "pop -> Pop from empty list is an error"
+
+[a4f9d2e1-7425-49ef-9ee8-6c0cb3407cf0]
+description = "pop -> Can pop from singleton list"
+
+[6dcbb2c9-d98a-47bc-a010-9c19703d3ea2]
+description = "pop -> Can pop from non-empty list"
+
+[e83aade9-f030-4096-aaf0-f9dc6491e6cf]
+description = "pop -> Can pop multiple items"
+
+[5c46bcf2-c0a9-4654-ae17-f3192436fcf1]
+description = "pop -> Pop updates the count"
+
+[70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b]
+description = "push -> Can push to an empty list"
+include = false
+
+[f3197f0a-1fea-45a5-939f-4a5ea60387ec]
+description = "push -> Can push to an empty list"
+reimplements = "70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b"
+
+[391e332e-1f91-4033-b1e0-0e0c17812fa7]
+description = "push -> Can push to a non-empty list"
+
+[ed4b0e01-3bbd-4895-af25-152b5914b3da]
+description = "push -> Push updates count"
+
+[41666790-b932-4e5a-b323-e848a83d12d5]
+description = "push -> Push and pop"
+
+[930a4a5c-76f6-47ec-9be3-4e70993173a1]
+description = "peek -> Peek on empty list is an error"
+
+[43255a50-d919-4e81-afce-e4a271eaedbd]
+description = "peek -> Can peek on singleton list"
+
+[48353020-e25d-4621-a854-e35fb1e15fa7]
+description = "peek -> Can peek on non-empty list"
+
+[96fcead9-a713-46c2-8005-3f246c873851]
+description = "peek -> Peek does not change the count"
+
+[7576ed05-7ff7-4b84-8efb-d34d62c110f5]
+description = "peek -> Can peek after a pop and push"
+
+[b97d00b6-2fab-435d-ae74-3233dcc13698]
+description = "toList LIFO -> Empty linked list to list is empty"
+
+[eedeb95f-b5cf-431d-8ad6-5854ba6b251c]
+description = "toList LIFO -> To list with multiple values"
+
+[838678de-eaf3-4c14-b34e-7e35b6d851e8]
+description = "toList LIFO -> To list after a pop"
+
+[03fc83a5-48a8-470b-a2d2-a286c5e8365f]
+description = "toList FIFO -> Empty linked list to list is empty"
+include = false
+
+[1282484e-a58c-426a-972e-90746bda61fc]
+description = "toList FIFO -> To list with multiple values"
+include = false
+
+[05ca3109-1249-4c0c-a567-a3b2f8352a7c]
+description = "toList FIFO -> To list after a pop"
+include = false
+
+[5e6c1a3d-e34b-46d3-be59-3f132a820ed5]
+description = "reverse -> Reversed empty list has same values"
+
+[93c87ed3-862a-474f-820b-ba3fd6b6daf6]
+description = "reverse -> Reversed singleton list is same list"
+
+[92851ebe-9f52-4406-b92e-0718c441a2ab]
+description = "reverse -> Reversed non-empty list is reversed"
+include = false
+
+[1210eeda-b23f-4790-930c-7ac6d0c8e723]
+description = "reverse -> Reversed non-empty list is reversed"
+reimplements = "92851ebe-9f52-4406-b92e-0718c441a2ab"
+
+[9b53af96-7494-4cfa-9b77-b7366fed5c4c]
+description = "reverse -> Double reverse"

--- a/exercises/practice/simple-linked-list/SimpleLinkedList.vb
+++ b/exercises/practice/simple-linked-list/SimpleLinkedList.vb
@@ -1,22 +1,30 @@
 Public Class SimpleLinkedList(Of T)
+    Public Sub New(ParamArray values As T())
+    End Sub
+
     Public ReadOnly Property Count As Integer
         Get
-            Return CSharpImpl.__Throw(Of Object)(New NotImplementedException("You need to implement this function."))
+            Throw New NotImplementedException("You need to implement this property.")
         End Get
     End Property
 
     Public Sub Push(ByVal value As T)
-        Throw New NotImplementedException("You need to implement this function.")
+        Throw New NotImplementedException("You need to implement this method.")
     End Sub
 
     Public Function Pop() As T
-        Throw New NotImplementedException("You need to implement this function.")
+        Throw New NotImplementedException("You need to implement this method.")
     End Function
 
-    Private Class CSharpImpl
-        <Obsolete("Please refactor calling code to use normal throw statements")>
-        Public Shared Function __Throw(Of T)(ByVal e As Exception) As T
-            Throw e
-        End Function
-    End Class
+    Public Function Peek() As T
+        Throw New NotImplementedException("You need to implement this method.")
+    End Function
+
+    Public Function ToList() As List(Of T)
+        Throw New NotImplementedException("You need to implement this method.")
+    End Function
+
+    Public Sub Reverse()
+        Throw New NotImplementedException("You need to implement this method.")
+    End Sub
 End Class

--- a/exercises/practice/simple-linked-list/SimpleLinkedListTests.vb
+++ b/exercises/practice/simple-linked-list/SimpleLinkedListTests.vb
@@ -1,98 +1,180 @@
 Public Class SimpleLinkedListTests
     <Fact>
-    Public Sub Empty_list_has_no_elements()
+    Public Sub Empty_list_has_length_of_zero()
         Dim list = New SimpleLinkedList(Of Integer)()
         Assert.Equal(0, list.Count)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Count_cannot_be_changed_from_the_outside()
-        Dim count = GetType(SimpleLinkedList(Of)).GetProperty("Count")
-        Assert.True(count?.GetGetMethod().IsPublic)
-        Assert.False(count?.GetSetMethod(True).IsPublic)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Pushing_elements_to_the_list_increases_the_count()
-        Dim list = New SimpleLinkedList(Of Integer)()
-        list.Push(0)
-        Assert.Equal(1, list.Count)
-        list.Push(0)
-        Assert.Equal(2, list.Count)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Popping_elements_from_the_list_decreases_the_count()
-        Dim list = New SimpleLinkedList(Of Integer)()
-        list.Push(0)
-        list.Push(0)
-        Assert.Equal(2, list.Count)
-        list.Pop()
+    Public Sub Singleton_list_has_length_of_one()
+        Dim list = New SimpleLinkedList(Of Integer)(1)
         Assert.Equal(1, list.Count)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Elements_pop_back_in_lifo_order()
+    Public Sub Non_empty_list_has_correct_length()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2, 3)
+        Assert.Equal(3, list.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Pop_from_empty_list_is_an_error()
         Dim list = New SimpleLinkedList(Of Integer)()
+        Assert.Throws(Of InvalidOperationException)(Function() list.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_pop_from_singleton_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1)
+        Assert.Equal(1, list.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_pop_from_non_empty_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        Assert.Equal(2, list.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_pop_multiple_items()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        Assert.Equal(2, list.Pop())
+        Assert.Equal(1, list.Pop())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Pop_updates_the_count()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        Assert.Equal(2, list.Count)
+        Assert.Equal(2, list.Pop())
+        Assert.Equal(1, list.Count)
+        Assert.Equal(1, list.Pop())
+        Assert.Equal(0, list.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_push_to_an_empty_list()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        list.Push(1)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_push_to_a_non_empty_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
         list.Push(3)
-        list.Push(5)
-        Assert.Equal(5, list.Pop())
-        list.Push(7)
-        Assert.Equal(7, list.Pop())
-        Assert.Equal(3, list.Pop())
-    End Sub
-
-    Private Shared Function CreateSimpleLinkedList(ByVal value As Integer) As SimpleLinkedList(Of Integer)
-        Dim type = GetType(SimpleLinkedList(Of)).MakeGenericType(GetType(Integer))
-        Dim constructor = type.GetConstructor(New Type() {GetType(Integer)})
-        Return If(CType(constructor?.Invoke(New Object() {value}), SimpleLinkedList(Of Integer)), CreateSimpleLinkedList(New Integer() {value}))
-    End Function
-
-    Private Shared Function CreateSimpleLinkedList(ParamArray values As Integer()) As SimpleLinkedList(Of Integer)
-        Dim type = GetType(SimpleLinkedList(Of)).MakeGenericType(GetType(Integer))
-        Dim constructor = type.GetConstructor(New Type() {GetType(Integer())})
-        Return CType(constructor.Invoke(New Object() {values}), SimpleLinkedList(Of Integer))
-    End Function
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Single_value_initialisation()
-        Dim list = CreateSimpleLinkedList(7)
-        Assert.Equal(1, list.Count)
-        Assert.Equal(7, list.Pop())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Multi_value_initialisation()
-        Dim list = CreateSimpleLinkedList(2, 1, 3)
+    Public Sub Push_updates_count()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        list.Push(3)
+        Assert.Equal(3, list.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Push_and_pop()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        list.Push(1)
+        list.Push(2)
+        Assert.Equal(2, list.Pop())
+        list.Push(3)
+        Assert.Equal(2, list.Count)
         Assert.Equal(3, list.Pop())
         Assert.Equal(1, list.Pop())
-        Assert.Equal(2, list.Pop())
+        Assert.Equal(0, list.Count)
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub From_enumerable()
-        Dim list = CreateSimpleLinkedList({11, 7, 5, 3, 2})
+    Public Sub Peek_on_empty_list_is_an_error()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        Assert.Throws(Of InvalidOperationException)(Function() list.Peek())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_peek_on_singleton_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1)
+        Assert.Equal(1, list.Peek())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_peek_on_non_empty_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        Assert.Equal(2, list.Peek())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Peek_does_not_change_the_count()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2)
+        Assert.Equal(2, list.Peek())
+        Assert.Equal(2, list.Count)
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Can_peek_after_a_pop_and_push()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        list.Push(1)
+        list.Push(2)
+        Assert.Equal(2, list.Peek())
+        Assert.Equal(2, list.Pop())
+        Assert.Equal(1, list.Peek())
+        list.Push(3)
+        Assert.Equal(3, list.Peek())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Empty_linked_list_to_list_is_empty()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        Assert.Empty(list.ToList())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub To_list_with_multiple_values()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2, 3)
+        Assert.Equal({3, 2, 1}, list.ToList())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub To_list_after_a_pop()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        list.Push(1)
+        list.Push(2)
+        list.Push(3)
+        Assert.Equal(3, list.Pop())
+        list.Push(4)
+        Assert.Equal({4, 2, 1}, list.ToList())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Reversed_empty_list_has_same_values()
+        Dim list = New SimpleLinkedList(Of Integer)()
+        list.Reverse()
+        Assert.Empty(list.ToList())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Reversed_singleton_list_is_same_list()
+        Dim list = New SimpleLinkedList(Of Integer)(1)
+        list.Reverse()
+        Assert.Equal({1}, list.ToList())
+    End Sub
+
+    <Fact(Skip:="Remove this Skip property to run this test")>
+    Public Sub Reversed_non_empty_list_is_reversed()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2, 3)
+        list.Reverse()
+        Assert.Equal(3, list.Count)
+        Assert.Equal(1, list.Pop())
         Assert.Equal(2, list.Pop())
         Assert.Equal(3, list.Pop())
-        Assert.Equal(5, list.Pop())
-        Assert.Equal(7, list.Pop())
-        Assert.Equal(11, list.Pop())
     End Sub
 
     <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Reverse_enumerable()
-        Dim values = Linq.Enumerable.Range(1, 5).ToArray()
-        Dim list = CreateSimpleLinkedList(values)
-        Dim enumerable = Assert.IsAssignableFrom(Of IEnumerable(Of Integer))(list)
-        Dim reversed = enumerable.Reverse()
-        Assert.Equal(values, reversed)
-    End Sub
-
-    <Fact(Skip:="Remove this Skip property to run this test")>
-    Public Sub Roundtrip()
-        Dim values = Linq.Enumerable.Range(1, 7)
-        Dim list = CreateSimpleLinkedList(values.ToArray())
-        Dim enumerable = Assert.IsAssignableFrom(Of IEnumerable(Of Integer))(list)
-        Assert.Equal(values.Reverse(), enumerable)
+    Public Sub Double_reverse()
+        Dim list = New SimpleLinkedList(Of Integer)(1, 2, 3)
+        list.Reverse()
+        list.Reverse()
+        Assert.Equal(3, list.Pop())
+        Assert.Equal(2, list.Pop())
+        Assert.Equal(1, list.Pop())
     End Sub
 End Class


### PR DESCRIPTION
Closes #499.

Tests will need to be rerun and will fail since the API is changed.